### PR TITLE
Set up resource group vending automation

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -1,0 +1,37 @@
+name: Terraform
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+
+      - name: Terraform Init
+        run: terraform -chdir=terraform init
+
+      - name: Terraform Format
+        run: terraform -chdir=terraform fmt -check
+
+      - name: Terraform Validate
+        run: terraform -chdir=terraform validate
+
+      - name: Terraform Plan
+        if: github.event_name == 'pull_request'
+        run: terraform -chdir=terraform plan
+
+      - name: Terraform Apply
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: terraform -chdir=terraform apply -auto-approve
+        env:
+          ARM_USE_OIDC: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.terraform/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# resource-group-vending
+# Resource Group Vending
+
+This repository provisions Azure resource groups for lab workloads using Terraform.
+Each workload is described by a YAML file under `workloads/`.
+
+## Workload YAML schema
+```yaml
+workload_name: Demo Workload
+workload_short_name: demowk    # 6-10 chars, no spaces or special characters
+location: eastus
+network_size: small            # small | medium | large
+environment: dev               # dev | test | prod
+github:
+  org: my-org
+  repo: resource-group-vending
+  entity: environment          # environment | branch | tag | pull_request
+  entity_name: demowk          # e.g. environment name
+```
+
+Managed identities and federated credentials are created automatically by Terraform.
+
+## Adding a workload
+1. Copy `workloads/demo.yaml` and adjust values.
+2. Commit the new file and open a pull request.
+3. GitHub Actions will run `terraform plan`.
+4. On merge to `main`, the workflow applies the changes and creates the resource group, managed identity, and federated credential.
+
+## Running locally
+```bash
+terraform -chdir=terraform init
+terraform -chdir=terraform plan
+terraform -chdir=terraform apply
+```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ github:
 ```
 
 Managed identities and federated credentials are created automatically by Terraform.
+The resource group is tagged with the workload name, short name, environment,
+GitHub organization and repository so that ownership is clear.
 
 ## Adding a workload
 1. Copy `workloads/demo.yaml` and adjust values.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+locals {
+  workload_files = fileset("${path.module}/../workloads", "*.yaml")
+  workloads = {
+    for file in local.workload_files :
+    trimsuffix(basename(file), ".yaml") => yamldecode(file("${path.module}/../workloads/${file}"))
+  }
+}
+
+module "workloads" {
+  source   = "./modules/resource_group"
+  for_each = local.workloads
+
+  workload_name       = each.value.workload_name
+  workload_short_name = each.value.workload_short_name
+  location            = each.value.location
+  network_size        = each.value.network_size
+  environment         = each.value.environment
+  github_org          = each.value.github.org
+  github_repo         = each.value.github.repo
+  github_entity       = each.value.github.entity
+  github_entity_name  = each.value.github.entity_name
+}

--- a/terraform/modules/resource_group/main.tf
+++ b/terraform/modules/resource_group/main.tf
@@ -2,9 +2,12 @@ resource "azurerm_resource_group" "rg" {
   name     = "rg-${var.workload_short_name}-${var.environment}"
   location = var.location
   tags = {
-    workload_name = var.workload_name
-    network_size  = var.network_size
-    environment   = var.environment
+    workload_name       = var.workload_name
+    workload_short_name = var.workload_short_name
+    network_size        = var.network_size
+    environment         = var.environment
+    github_org          = var.github_org
+    github_repo         = var.github_repo
   }
 }
 

--- a/terraform/modules/resource_group/main.tf
+++ b/terraform/modules/resource_group/main.tf
@@ -1,0 +1,33 @@
+resource "azurerm_resource_group" "rg" {
+  name     = "rg-${var.workload_short_name}-${var.environment}"
+  location = var.location
+  tags = {
+    workload_name = var.workload_name
+    network_size  = var.network_size
+    environment   = var.environment
+  }
+}
+
+resource "azurerm_user_assigned_identity" "uai" {
+  name                = "uai-${var.workload_short_name}-${var.environment}"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
+}
+
+resource "azurerm_role_assignment" "owner" {
+  scope                = azurerm_resource_group.rg.id
+  role_definition_name = "Owner"
+  principal_id         = azurerm_user_assigned_identity.uai.principal_id
+}
+
+resource "azurerm_federated_identity_credential" "github" {
+  name                      = "fic-${var.workload_short_name}-${var.environment}"
+  user_assigned_identity_id = azurerm_user_assigned_identity.uai.id
+  issuer                    = "https://token.actions.githubusercontent.com"
+  subject                   = "repo:${var.github_org}/${var.github_repo}:${var.github_entity}:${var.github_entity_name}"
+  audiences                 = ["api://AzureADTokenExchange"]
+}
+
+output "resource_group_id" {
+  value = azurerm_resource_group.rg.id
+}

--- a/terraform/modules/resource_group/variables.tf
+++ b/terraform/modules/resource_group/variables.tf
@@ -1,0 +1,9 @@
+variable "workload_name" { type = string }
+variable "workload_short_name" { type = string }
+variable "location" { type = string }
+variable "network_size" { type = string }
+variable "environment" { type = string }
+variable "github_org" { type = string }
+variable "github_repo" { type = string }
+variable "github_entity" { type = string }
+variable "github_entity_name" { type = string }

--- a/workloads/demo.yaml
+++ b/workloads/demo.yaml
@@ -1,0 +1,10 @@
+workload_name: Demo Workload
+workload_short_name: demowk
+location: eastus
+network_size: small
+environment: dev
+github:
+  org: my-org
+  repo: resource-group-vending
+  entity: environment
+  entity_name: demowk


### PR DESCRIPTION
## Summary
- add YAML example for workloads
- create Terraform module for resource group, managed identity, and federated credential
- use main Terraform configuration to consume workload YAML files
- add GitHub Actions workflow for Terraform
- document YAML schema and usage

## Testing
- `terraform init` *(fails: could not connect to registry)*
- `terraform validate` *(fails: missing required provider)*

------
https://chatgpt.com/codex/tasks/task_e_687bb4f49d3083308d2185350d5654cb