### PR TITLE
Limit workflow triggers to infra directories

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -3,7 +3,13 @@ name: Terraform
 on:
   push:
     branches: [main]
+    paths:
+      - 'terraform/**'
+      - 'workloads/**'
   pull_request:
+    paths:
+      - 'terraform/**'
+      - 'workloads/**'
 
 jobs:
   terraform:


### PR DESCRIPTION
## Summary
- only run CI when files change under terraform or workloads

## Testing
- `terraform -chdir=terraform fmt -check`
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_688280da816883309862255f396cf66b