### PR TITLE
Add service identifier property

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ workload_short_name: demowk    # 6-10 chars, no spaces or special characters
 location: eastus
 network_size: small            # small | medium | large
 environment: dev               # dev | test | prod
+service_identifier: svc-12345  # service identifier from Port
 github:
   org: my-org
   repo: resource-group-vending

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -29,6 +29,7 @@ module "workloads" {
   location            = each.value.location
   network_size        = each.value.network_size
   environment         = each.value.environment
+  service_identifier  = each.value.service_identifier
   github_org          = each.value.github.org
   github_repo         = each.value.github.repo
   github_entity       = each.value.github.entity

--- a/terraform/modules/resource_group/main.tf
+++ b/terraform/modules/resource_group/main.tf
@@ -6,6 +6,7 @@ resource "azurerm_resource_group" "rg" {
     workload_short_name = var.workload_short_name
     network_size        = var.network_size
     environment         = var.environment
+    service_identifier  = var.service_identifier
     github_org          = var.github_org
     github_repo         = var.github_repo
   }

--- a/terraform/modules/resource_group/variables.tf
+++ b/terraform/modules/resource_group/variables.tf
@@ -3,6 +3,7 @@ variable "workload_short_name" { type = string }
 variable "location" { type = string }
 variable "network_size" { type = string }
 variable "environment" { type = string }
+variable "service_identifier" { type = string }
 variable "github_org" { type = string }
 variable "github_repo" { type = string }
 variable "github_entity" { type = string }

--- a/workloads/demo.yaml
+++ b/workloads/demo.yaml
@@ -3,6 +3,7 @@ workload_short_name: demowk
 location: eastus
 network_size: small
 environment: dev
+service_identifier: svc-12345
 github:
   org: my-org
   repo: resource-group-vending


### PR DESCRIPTION
## Summary
- support new `service_identifier` in workload YAML
- tag resource groups with the service identifier
- update example demo YAML

## Testing
- `terraform -chdir=terraform fmt -check`
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_688282e51ea083309e617787d8d9e31a