### PR TITLE
refactor: rename workloads to environments

### DIFF
--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -1,4 +1,4 @@
-name: Provision Workload
+name: Provision Environment
 
 on:
   workflow_dispatch:
@@ -66,7 +66,7 @@ jobs:
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
 
-      - name: Log start workload file creation
+      - name: Log start environment file creation
         uses: port-labs/port-github-action@v1
         with:
           clientId: ${{ secrets.PORT_CLIENT_ID }}
@@ -74,15 +74,16 @@ jobs:
           baseUrl: https://api.getport.io
           operation: PATCH_RUN
           runId: ${{ env.PORT_RUN_ID }}
-          logMessage: 'Starting workload file creation'
+          logMessage: 'Starting environment file creation'
 
-      - name: Create workload file
+      - name: Create environment file
+        id: create_env_file
         run: |
           ORG=$(echo "${{ inputs.github_repo }}" | cut -d'/' -f1)
           REPO=$(echo "${{ inputs.github_repo }}" | cut -d'/' -f2)
-          cat <<EOF > workloads/${{ inputs.service_short_name }}.yaml
-          workload_name: ${{ inputs.service_name }}
-          workload_short_name: ${{ inputs.service_short_name }}
+          cat <<EOF > environments/${{ inputs.service_short_name }}.yaml
+          environment_name: ${{ inputs.service_name }}
+          environment_short_name: ${{ inputs.service_short_name }}
           location: ${{ inputs.location }}
           environment: ${{ inputs.environment }}
           service_identifier: ${{ inputs.service_identifier }}
@@ -92,6 +93,19 @@ jobs:
             entity: environment
             entity_name: ${{ inputs.service_short_name }}
           EOF
+          echo "file_content<<EOF" >> $GITHUB_OUTPUT
+          cat environments/${{ inputs.service_short_name }}.yaml >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Log environment file content
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{ env.PORT_RUN_ID }}
+          logMessage: ${{ steps.create_env_file.outputs.file_content }}
 
       - name: Log start terraform init
         uses: port-labs/port-github-action@v1
@@ -173,14 +187,14 @@ jobs:
           baseUrl: https://api.getport.io
           operation: PATCH_RUN
           runId: ${{ env.PORT_RUN_ID }}
-          logMessage: 'Appending Terraform outputs to workload file'
+          logMessage: 'Appending Terraform outputs to environment file'
 
-      - name: Append outputs to workload file
+      - name: Append outputs to environment file
         run: |
           RGID=$(jq -r ".resource_group_ids.value[\"${{ inputs.service_short_name }}\"]" tfoutput.json)
-          echo "resource_group_id: $RGID" >> workloads/${{ inputs.service_short_name }}.yaml
+          echo "resource_group_id: $RGID" >> environments/${{ inputs.service_short_name }}.yaml
 
-      - name: Log start commit workload file
+      - name: Log start commit environment file
         uses: port-labs/port-github-action@v1
         with:
           clientId: ${{ secrets.PORT_CLIENT_ID }}
@@ -188,14 +202,14 @@ jobs:
           baseUrl: https://api.getport.io
           operation: PATCH_RUN
           runId: ${{ env.PORT_RUN_ID }}
-          logMessage: 'Committing workload file'
+          logMessage: 'Committing environment file'
 
-      - name: Commit workload file
+      - name: Commit environment file
         run: |
           git config user.email "75343302+getport-io[bot]@users.noreply.github.com"
           git config user.name "getport-io[bot]"
-          git add workloads/${{ inputs.service_short_name }}.yaml
-          git commit -m "Add workload ${{ inputs.service_short_name }}"
+          git add environments/${{ inputs.service_short_name }}.yaml
+          git commit -m "Add environment ${{ inputs.service_short_name }}"
           git push origin HEAD:main
 
       - name: Mark run success

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Resource Group Vending
 
-This repository provisions Azure resource groups for lab workloads using Terraform. 
-Workloads are provisioned through a GitHub Actions workflow triggered by Port. The workflow runs Terraform with the provided inputs and commits a YAML file under `workloads/` containing the configuration and generated resource group id.
+This repository provisions Azure resource groups for lab environments using Terraform.
+Environments are provisioned through a GitHub Actions workflow triggered by Port. The workflow runs Terraform with the provided inputs and commits a YAML file under `environments/` containing the configuration and generated resource group id.
 
-## Workload YAML schema
+## Environment YAML schema
 ```yaml
-workload_name: Demo Workload
-workload_short_name: demowk    # 6-10 chars, no spaces or special characters
+environment_name: Demo Environment
+environment_short_name: demoenv    # 6-10 chars, no spaces or special characters
 location: eastus
 network_size: small            # small | medium | large
 environment: dev               # dev | test | prod
@@ -15,15 +15,15 @@ github:
   org: my-org
   repo: resource-group-vending
   entity: environment          # environment | branch | tag | pull_request
-  entity_name: demowk          # e.g. environment name
+  entity_name: demoenv          # e.g. environment name
 ```
 
 Managed identities and federated credentials are created automatically by Terraform.
-The resource group is tagged with the workload name, short name, environment,
+The resource group is tagged with the environment name, short name, environment,
 GitHub organization and repository so that ownership is clear.
 
-## Provisioning a workload
-Port invokes the **Provision Workload** workflow with workload details. On success, the workflow provisions the resources and commits the corresponding YAML file to the repository.
+## Provisioning an environment
+Port invokes the **Provision Environment** workflow with environment details. On success, the workflow provisions the resources and commits the corresponding YAML file to the repository.
 
 ## Running locally
 ```bash

--- a/environments/demo.yaml
+++ b/environments/demo.yaml
@@ -1,5 +1,5 @@
-workload_name: Demo Workload
-workload_short_name: demowk
+environment_name: Demo Environment
+environment_short_name: demoenv
 location: eastus
 network_size: small
 environment: dev
@@ -8,4 +8,4 @@ github:
   org: my-org
   repo: resource-group-vending
   entity: environment
-  entity_name: demowk
+  entity_name: demoenv

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -21,31 +21,31 @@ provider "port" {
 }
 
 locals {
-  workload_files = fileset("${path.module}/../workloads", "*.yaml")
-  workloads = {
-    for file in local.workload_files :
-    trimsuffix(basename(file), ".yaml") => yamldecode(file("${path.module}/../workloads/${file}"))
+  environment_files = fileset("${path.module}/../environments", "*.yaml")
+  environments = {
+    for file in local.environment_files :
+    trimsuffix(basename(file), ".yaml") => yamldecode(file("${path.module}/../environments/${file}"))
   }
 }
 
-module "workloads" {
+module "environments" {
   source   = "./modules/resource_group"
-  for_each = local.workloads
+  for_each = local.environments
 
-  workload_name       = each.value.workload_name
-  workload_short_name = each.value.workload_short_name
-  location            = each.value.location
-  network_size        = each.value.network_size
-  environment         = each.value.environment
-  service_identifier  = each.value.service_identifier
-  github_org          = each.value.github.org
-  github_repo         = each.value.github.repo
-  github_entity       = each.value.github.entity
-  github_entity_name  = each.value.github.entity_name
+  environment_name       = each.value.environment_name
+  environment_short_name = each.value.environment_short_name
+  location               = each.value.location
+  network_size           = each.value.network_size
+  environment            = each.value.environment
+  service_identifier     = each.value.service_identifier
+  github_org             = each.value.github.org
+  github_repo            = each.value.github.repo
+  github_entity          = each.value.github.entity
+  github_entity_name     = each.value.github.entity_name
 }
 
 resource "port_entity" "environment" {
-  for_each = local.workloads
+  for_each = local.environments
 
   blueprint  = "environment"
   identifier = "${each.value.service_identifier}_${each.value.environment}"
@@ -53,11 +53,11 @@ resource "port_entity" "environment" {
 
   relations = {
     single_relations = {
-      workload = "${each.value.workload_name}_${each.value.environment}"
+      environment = "${each.value.environment_name}_${each.value.environment}"
     }
   }
 }
 
 output "resource_group_ids" {
-  value = { for k, m in module.workloads : k => m.resource_group_id }
+  value = { for k, m in module.environments : k => m.resource_group_id }
 }

--- a/terraform/modules/resource_group/main.tf
+++ b/terraform/modules/resource_group/main.tf
@@ -1,19 +1,19 @@
 resource "azurerm_resource_group" "rg" {
-  name     = "rg-${var.workload_short_name}-${var.environment}"
+  name     = "rg-${var.environment_short_name}-${var.environment}"
   location = var.location
   tags = {
-    workload_name       = var.workload_name
-    workload_short_name = var.workload_short_name
-    network_size        = var.network_size
-    environment         = var.environment
-    service_identifier  = var.service_identifier
-    github_org          = var.github_org
-    github_repo         = var.github_repo
+    environment_name       = var.environment_name
+    environment_short_name = var.environment_short_name
+    network_size           = var.network_size
+    environment            = var.environment
+    service_identifier     = var.service_identifier
+    github_org             = var.github_org
+    github_repo            = var.github_repo
   }
 }
 
 resource "azurerm_user_assigned_identity" "uai" {
-  name                = "uai-${var.workload_short_name}-${var.environment}"
+  name                = "uai-${var.environment_short_name}-${var.environment}"
   location            = var.location
   resource_group_name = azurerm_resource_group.rg.name
 }
@@ -25,7 +25,7 @@ resource "azurerm_role_assignment" "owner" {
 }
 
 resource "azurerm_federated_identity_credential" "github" {
-  name                = "fic-${var.workload_short_name}-${var.environment}"
+  name                = "fic-${var.environment_short_name}-${var.environment}"
   resource_group_name = azurerm_resource_group.rg.name
   parent_id           = azurerm_user_assigned_identity.uai.id
   issuer              = "https://token.actions.githubusercontent.com"

--- a/terraform/modules/resource_group/variables.tf
+++ b/terraform/modules/resource_group/variables.tf
@@ -1,5 +1,5 @@
-variable "workload_name" { type = string }
-variable "workload_short_name" { type = string }
+variable "environment_name" { type = string }
+variable "environment_short_name" { type = string }
 variable "location" { type = string }
 variable "network_size" { type = string }
 variable "environment" { type = string }


### PR DESCRIPTION
## Summary
- rename workloads concept to environments and update all related configs
- log environment file content to Port during provisioning workflow

## Testing
- `terraform -chdir=terraform fmt -recursive`
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_6894d0cf9c6483308d91539390c65f4e