### PR TITLE
Add Port entities for Azure infrastructure

### DIFF
--- a/terraform/modules/resource_group/main.tf
+++ b/terraform/modules/resource_group/main.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+    port = {
+      source = "port-labs/port-labs"
+    }
+  }
+}
+
 resource "azurerm_resource_group" "rg" {
   name     = "rg-${var.environment_short_name}-${var.environment}"
   location = var.location
@@ -10,6 +21,15 @@ resource "azurerm_resource_group" "rg" {
     github_org             = var.github_org
     github_repo            = var.github_repo
   }
+}
+
+resource "azurerm_storage_account" "sa" {
+  name                     = "st${lower(var.environment_short_name)}${var.environment}"
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = var.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  tags                     = azurerm_resource_group.rg.tags
 }
 
 resource "azurerm_user_assigned_identity" "uai" {
@@ -31,6 +51,59 @@ resource "azurerm_federated_identity_credential" "github" {
   issuer              = "https://token.actions.githubusercontent.com"
   subject             = "repo:${var.github_org}/${var.github_repo}:${var.github_entity}:${var.github_entity_name}"
   audience            = ["api://AzureADTokenExchange"]
+}
+
+resource "port_entity" "resource_group" {
+  blueprint  = "azureResourceGroup"
+  identifier = azurerm_resource_group.rg.name
+  title      = azurerm_resource_group.rg.name
+
+  properties = {
+    location = azurerm_resource_group.rg.location
+    tags     = azurerm_resource_group.rg.tags
+  }
+
+  relations = {
+    single_relations = {
+      environment = "${var.service_identifier}_${var.environment}"
+    }
+  }
+}
+
+resource "port_entity" "storage_account" {
+  blueprint  = "azureStorageAccount"
+  identifier = azurerm_storage_account.sa.name
+  title      = azurerm_storage_account.sa.name
+
+  properties = {
+    location          = azurerm_storage_account.sa.location
+    isHnsEnabled      = azurerm_storage_account.sa.is_hns_enabled
+    primaryLocation   = azurerm_storage_account.sa.primary_location
+    secondaryLocation = azurerm_storage_account.sa.secondary_location
+    tags              = azurerm_storage_account.sa.tags
+  }
+
+  relations = {
+    single_relations = {
+      resourceGroup = port_entity.resource_group.identifier
+    }
+  }
+}
+
+resource "port_entity" "user_managed_identity" {
+  blueprint  = "azureUserManagedIdentity"
+  identifier = azurerm_user_assigned_identity.uai.name
+  title      = azurerm_user_assigned_identity.uai.name
+
+  properties = {
+    clientId = azurerm_user_assigned_identity.uai.client_id
+  }
+
+  relations = {
+    single_relations = {
+      resource_group = port_entity.resource_group.identifier
+    }
+  }
 }
 
 output "resource_group_id" {


### PR DESCRIPTION
## Summary
- provision a storage account alongside each resource group
- register resource group, storage account and user managed identity in Port

## Testing
- `terraform -chdir=terraform fmt -recursive`
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_6894d3a2f6d4833096fc70f40e8ed609