### PR TITLE
Add Port entities for Azure infrastructure

### DIFF
--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -40,6 +40,8 @@ jobs:
       ARM_TENANT_ID: ${{ secrets.AZURETENANTID }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.AZURESUBSCRIPTIONID }}
       PORT_RUN_ID: ${{ fromJson(inputs.port_context).runId }}
+      PORT_CLIENT_ID: ${{ secrets.PORT_CLIENT_ID }}
+      PORT_CLIENT_SECRET: ${{ secrets.PORT_CLIENT_SECRET }}
     steps:
       - name: Start run
         uses: port-labs/port-github-action@v1

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Environments are provisioned through a GitHub Actions workflow triggered by Port
 environment_name: Demo Environment
 environment_short_name: demoenv    # 6-10 chars, no spaces or special characters
 location: eastus
-network_size: small            # small | medium | large
 environment: dev               # dev | test | prod
 service_identifier: svc-12345  # service identifier from Port
 github:

--- a/environments/demo.yaml
+++ b/environments/demo.yaml
@@ -1,7 +1,6 @@
 environment_name: Demo Environment
 environment_short_name: demoenv
 location: eastus
-network_size: small
 environment: dev
 service_identifier: svc-12345
 github:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -16,9 +16,7 @@ provider "azurerm" {
   features {}
 }
 
-provider "port" {
-  # Credentials are read from PORT_CLIENT_ID and PORT_CLIENT_SECRET
-}
+provider "port" {}
 
 locals {
   environment_files = fileset("${path.module}/../environments", "*.yaml")
@@ -35,7 +33,6 @@ module "environments" {
   environment_name       = each.value.environment_name
   environment_short_name = each.value.environment_short_name
   location               = each.value.location
-  network_size           = each.value.network_size
   environment            = each.value.environment
   service_identifier     = each.value.service_identifier
   github_org             = each.value.github.org

--- a/terraform/modules/resource_group/main.tf
+++ b/terraform/modules/resource_group/main.tf
@@ -1,10 +1,20 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+    port = {
+      source = "port-labs/port-labs"
+    }
+  }
+}
+
 resource "azurerm_resource_group" "rg" {
   name     = "rg-${var.environment_short_name}-${var.environment}"
   location = var.location
   tags = {
     environment_name       = var.environment_name
     environment_short_name = var.environment_short_name
-    network_size           = var.network_size
     environment            = var.environment
     service_identifier     = var.service_identifier
     github_org             = var.github_org
@@ -12,11 +22,22 @@ resource "azurerm_resource_group" "rg" {
   }
 }
 
+resource "azurerm_storage_account" "sa" {
+  name                     = "st${lower(var.environment_short_name)}${var.environment}"
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = var.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  tags                     = azurerm_resource_group.rg.tags
+}
+
 resource "azurerm_user_assigned_identity" "uai" {
   name                = "uai-${var.environment_short_name}-${var.environment}"
   location            = var.location
   resource_group_name = azurerm_resource_group.rg.name
 }
+
+data "azurerm_subscription" "current" {}
 
 resource "azurerm_role_assignment" "owner" {
   scope                = azurerm_resource_group.rg.id
@@ -31,6 +52,61 @@ resource "azurerm_federated_identity_credential" "github" {
   issuer              = "https://token.actions.githubusercontent.com"
   subject             = "repo:${var.github_org}/${var.github_repo}:${var.github_entity}:${var.github_entity_name}"
   audience            = ["api://AzureADTokenExchange"]
+}
+
+resource "port_entity" "resource_group" {
+  blueprint  = "azureResourceGroup"
+  identifier = azurerm_resource_group.rg.name
+  title      = azurerm_resource_group.rg.name
+
+  properties = {
+    location = azurerm_resource_group.rg.location
+    tags     = azurerm_resource_group.rg.tags
+  }
+
+  relations = {
+    single_relations = {
+      environment  = "${var.service_identifier}_${var.environment}"
+      subscription = data.azurerm_subscription.current.subscription_id
+    }
+  }
+}
+
+resource "port_entity" "storage_account" {
+  blueprint  = "azureStorageAccount"
+  identifier = azurerm_storage_account.sa.name
+  title      = azurerm_storage_account.sa.name
+
+  properties = {
+    location              = azurerm_storage_account.sa.location
+    isHnsEnabled          = azurerm_storage_account.sa.is_hns_enabled
+    primaryLocation       = azurerm_storage_account.sa.primary_location
+    secondaryLocation     = azurerm_storage_account.sa.secondary_location
+    allowBlobPublicAccess = azurerm_storage_account.sa.allow_nested_items_to_be_public
+    tags                  = azurerm_storage_account.sa.tags
+  }
+
+  relations = {
+    single_relations = {
+      resourceGroup = port_entity.resource_group.identifier
+    }
+  }
+}
+
+resource "port_entity" "user_managed_identity" {
+  blueprint  = "azureUserManagedIdentity"
+  identifier = azurerm_user_assigned_identity.uai.name
+  title      = azurerm_user_assigned_identity.uai.name
+
+  properties = {
+    clientId = azurerm_user_assigned_identity.uai.client_id
+  }
+
+  relations = {
+    single_relations = {
+      resource_group = port_entity.resource_group.identifier
+    }
+  }
 }
 
 output "resource_group_id" {

--- a/terraform/modules/resource_group/variables.tf
+++ b/terraform/modules/resource_group/variables.tf
@@ -1,7 +1,6 @@
 variable "environment_name" { type = string }
 variable "environment_short_name" { type = string }
 variable "location" { type = string }
-variable "network_size" { type = string }
 variable "environment" { type = string }
 variable "service_identifier" { type = string }
 variable "github_org" { type = string }


### PR DESCRIPTION
## Summary
- provision a storage account alongside each resource group
- register resource group, storage account and user managed identity in Port
- associate resource group entity with subscription and expose storage account blob access setting
- allow Port provider to use credentials from environment variables
- remove network size variable from environment definitions

## Testing
- `terraform -chdir=terraform fmt -recursive`
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_6894d3a2f6d4833096fc70f40e8ed609