### PR TITLE
Refactor terraform for workflow-specific state

### DIFF
--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -43,6 +43,7 @@ jobs:
       TF_VAR_port_run_id: ${{ fromJson(inputs.port_context).runId }}
       PORT_CLIENT_ID: ${{ secrets.PORT_CLIENT_ID }}
       PORT_CLIENT_SECRET: ${{ secrets.PORT_CLIENT_SECRET }}
+      TF_VAR_environment_file: environments/${{ inputs.service_short_name }}_${{ inputs.environment }}_${{ inputs.location }}.yaml
     steps:
       - name: Start run
         uses: port-labs/port-github-action@v1
@@ -55,6 +56,32 @@ jobs:
           logMessage: 'Provisioning started'
 
       - uses: actions/checkout@v3
+
+      - name: Check for existing environment file
+        id: check_env
+        run: |
+          if [ -f environments/${{ inputs.service_short_name }}_${{ inputs.environment }}_${{ inputs.location }}.yaml ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Log existing environment file
+        if: steps.check_env.outputs.exists == 'true'
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{ env.PORT_RUN_ID }}
+          status: FAILURE
+          logMessage: 'Environment file already exists'
+
+      - name: Stop if environment file exists
+        if: steps.check_env.outputs.exists == 'true'
+        run: exit 1
+
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -99,7 +126,7 @@ jobs:
             entity_name: ${{ inputs.service_short_name }}
           EOF
           echo "file_content<<EOF" >> $GITHUB_OUTPUT
-          cat environments/${{ inputs.service_short_name }}_${{ inputs.environment }}.yaml >> $GITHUB_OUTPUT
+          cat environments/${{ inputs.service_short_name }}_${{ inputs.environment }}_${{ inputs.location }}.yaml >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Log environment file content
@@ -126,14 +153,14 @@ jobs:
         run: |
           git config user.email "75343302+getport-io[bot]@users.noreply.github.com"
           git config user.name "getport-io[bot]"
-          git add environments/${{ inputs.service_short_name }}_${{ inputs.environment }}.yaml
-          git commit -m "Add environment ${{ inputs.service_short_name }}_${{ inputs.environment }}"
+          git add environments/${{ inputs.service_short_name }}_${{ inputs.environment }}_${{ inputs.location }}.yaml
+          git commit -m "Add environment ${{ inputs.service_short_name }}_${{ inputs.environment }}_${{ inputs.location }}"
           git push origin HEAD:main
 
       - name: Create state container
         run: |
           az storage container create \
-            --name ${{ inputs.service_short_name }}_${{ inputs.environment }}_${{ inputs.location }} }} \
+            --name ${{ inputs.service_short_name }}_${{ inputs.environment }}_${{ inputs.location }} \
             --account-name vendingtfstate \
             --resource-group v1vhm-rg-vending-prod-uks-001 \
             --auth-mode login
@@ -149,7 +176,13 @@ jobs:
           logMessage: 'Starting Terraform Init'
 
       - name: Terraform Init
-        run: terraform -chdir=terraform init
+        run: |
+          terraform -chdir=terraform init \
+            -backend-config="resource_group_name=v1vhm-rg-vending-prod-uks-001" \
+            -backend-config="storage_account_name=vendingtfstate" \
+            -backend-config="container_name=${{ inputs.service_short_name }}_${{ inputs.environment }}_${{ inputs.location }}" \
+            -backend-config="key=${{ inputs.service_short_name }}_${{ inputs.environment }}_${{ inputs.location }}.tfstate" \
+            -reconfigure
 
       - name: Log start terraform plan
         uses: port-labs/port-github-action@v1
@@ -222,8 +255,8 @@ jobs:
 
       - name: Append outputs to environment file
         run: |
-          RGID=$(jq -r ".resource_group_ids.value[\"${{ inputs.service_short_name }}\"]" tfoutput.json)
-          echo "resource_group_id: $RGID" >> environments/${{ inputs.service_short_name }}_${{ inputs.environment }}.yaml
+          RGID=$(jq -r '.resource_group_id.value' tfoutput.json)
+          echo "resource_group_id: $RGID" >> environments/${{ inputs.service_short_name }}_${{ inputs.environment }}_${{ inputs.location }}.yaml
 
       - name: Log start commit updated environment file
         uses: port-labs/port-github-action@v1
@@ -239,8 +272,8 @@ jobs:
         run: |
           git config user.email "75343302+getport-io[bot]@users.noreply.github.com"
           git config user.name "getport-io[bot]"
-          git add environments/${{ inputs.service_short_name }}_${{ inputs.environment }}.yaml
-          git commit -m "Update environment ${{ inputs.service_short_name }}_${{ inputs.environment }} with outputs"
+          git add environments/${{ inputs.service_short_name }}_${{ inputs.environment }}_${{ inputs.location }}.yaml
+          git commit -m "Update environment ${{ inputs.service_short_name }}_${{ inputs.environment }}_${{ inputs.location }} with outputs"
           git push origin HEAD:main
 
       - name: Mark run success

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,8 +1,3 @@
 terraform {
-  backend "azurerm" {
-    resource_group_name  = "v1vhm-rg-vending-prod-uks-001"
-    storage_account_name = "vendingtfstate"
-    container_name       = "tf-state"
-    key                  = "terraform.tfstate"
-  }
+  backend "azurerm" {}
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,7 @@
 variable "port_run_id" {
   type = string
 }
+
+variable "environment_file" {
+  type = string
+}


### PR DESCRIPTION
## Summary
- externalize Azure backend configuration so pipeline can provide state file
- load a single environment YAML via `environment_file` variable to avoid touching other environments
- initialize Terraform with dynamic backend settings in the workflow before plan/apply
- abort early if environment file already exists, logging failure to Port

## Testing
- `terraform -chdir=terraform fmt -check`
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_689522ea32e4833088671c2f3bda7db0