### PR TITLE
Grant managed identity blob contributor role

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ github:
   entity_name: demoenv          # e.g. environment name
 ```
 
-Managed identities and federated credentials are created automatically by Terraform.
+Managed identities and federated credentials are created automatically by Terraform. The identity is granted Owner access to the resource group and Storage Blob Data Contributor access to the storage account.
 The resource group is tagged with the environment name, short name, environment,
 GitHub organization and repository so that ownership is clear.
 

--- a/terraform/modules/resource_group/main.tf
+++ b/terraform/modules/resource_group/main.tf
@@ -45,6 +45,12 @@ resource "azurerm_role_assignment" "owner" {
   principal_id         = azurerm_user_assigned_identity.uai.principal_id
 }
 
+resource "azurerm_role_assignment" "storage_blob_data_contributor" {
+  scope                = azurerm_storage_account.sa.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_user_assigned_identity.uai.principal_id
+}
+
 resource "azurerm_federated_identity_credential" "github" {
   name                = "fic-${var.environment_short_name}-${var.environment}"
   resource_group_name = azurerm_resource_group.rg.name


### PR DESCRIPTION
## Summary
- grant user-assigned identity Storage Blob Data Contributor on the storage account
- document identity role assignments in README

## Testing
- `terraform -chdir=terraform/modules/resource_group init -backend=false`
- `terraform -chdir=terraform/modules/resource_group validate`


------
https://chatgpt.com/codex/tasks/task_e_6895a30707788330a9fbc856152db883