### PR TITLE
Support product metadata and multiple services in resource group module

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -31,18 +31,16 @@ module "environment" {
   environment_short_name = local.environment.environment_short_name
   location               = local.environment.location
   environment            = local.environment.environment
-  service_identifier     = local.environment.service_identifier
-  github_org             = local.environment.github.org
-  github_repo            = local.environment.github.repo
-  github_entity          = local.environment.github.entity
-  github_entity_name     = local.environment.github.entity_name
+  product_name           = local.environment.product_name
+  product_identifier     = local.environment.product_identifier
+  services               = try(local.environment.services, [])
   port_run_id            = var.port_run_id
 }
 
 resource "port_entity" "environment" {
   blueprint  = "environment"
-  identifier = "${local.environment.service_identifier}_${local.environment.environment}_${local.environment.location}"
-  title      = "${local.environment.service_identifier}-${local.environment.environment}"
+  identifier = "${local.environment.product_identifier}_${local.environment.environment}_${local.environment.location}"
+  title      = "${local.environment.product_identifier}-${local.environment.environment}"
 
   properties = {
     environment_type = "Azure Resource Group"

--- a/terraform/modules/resource_group/main.tf
+++ b/terraform/modules/resource_group/main.tf
@@ -16,9 +16,8 @@ resource "azurerm_resource_group" "rg" {
     environment_name       = var.environment_name
     environment_short_name = var.environment_short_name
     environment            = var.environment
-    service_identifier     = var.service_identifier
-    github_org             = var.github_org
-    github_repo            = var.github_repo
+    product_identifier     = var.product_identifier
+    product_name           = var.product_name
   }
 }
 
@@ -52,11 +51,12 @@ resource "azurerm_role_assignment" "storage_blob_data_contributor" {
 }
 
 resource "azurerm_federated_identity_credential" "github" {
-  name                = "fic-${var.environment_short_name}-${var.environment}"
+  for_each            = { for s in var.services : s.service_identifier => s }
+  name                = "fic-${var.environment_short_name}-${var.environment}-${each.key}"
   resource_group_name = azurerm_resource_group.rg.name
   parent_id           = azurerm_user_assigned_identity.uai.id
   issuer              = "https://token.actions.githubusercontent.com"
-  subject             = "repo:${var.github_org}/${var.github_repo}:${var.github_entity}:${var.github_entity_name}"
+  subject             = "repo:${each.value.github.org}/${each.value.github.repo}:${each.value.github.entity}:${each.value.github.entity_name}"
   audience            = ["api://AzureADTokenExchange"]
 }
 

--- a/terraform/modules/resource_group/variables.tf
+++ b/terraform/modules/resource_group/variables.tf
@@ -2,9 +2,18 @@ variable "environment_name" { type = string }
 variable "environment_short_name" { type = string }
 variable "location" { type = string }
 variable "environment" { type = string }
-variable "service_identifier" { type = string }
-variable "github_org" { type = string }
-variable "github_repo" { type = string }
-variable "github_entity" { type = string }
-variable "github_entity_name" { type = string }
+variable "product_identifier" { type = string }
+variable "product_name" { type = string }
+variable "services" {
+  type = list(object({
+    service_identifier = string
+    github = object({
+      org         = string
+      repo        = string
+      entity      = string
+      entity_name = string
+    })
+  }))
+  default = []
+}
 variable "port_run_id" { type = string }


### PR DESCRIPTION
## Summary
- switch resource group module to product tags and metadata
- create federated credentials for each service in environment
- identify Port environment entities by product identifier

## Testing
- `terraform fmt -recursive`
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_689ee8dbaff48330b96d772ec7e58261