### PR TITLE
Associate services with environments in Port

### DIFF
--- a/.github/workflows/associate-service.yml
+++ b/.github/workflows/associate-service.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Terraform Plan
         run: terraform -chdir=terraform plan -no-color
 
-      - name: Terraform Apply
+      - name: Terraform Apply (update Port relations)
         run: terraform -chdir=terraform apply -auto-approve -no-color
 
       - name: Mark run success

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -56,6 +56,9 @@ resource "port_entity" "environment" {
       azure_subscription     = data.azurerm_subscription.current.id
       product                = local.product_identifier
     }
+    many_relations = length(local.services) > 0 ? {
+      deployed_service = [for s in local.services : s.service_identifier]
+    } : null
   }
 
   run_id = var.port_run_id


### PR DESCRIPTION
## Summary
- link environment entity to deployed services using Port relations
- clarify apply step in service association workflow

## Testing
- `terraform fmt -recursive`
- `TF_VAR_environment_file=/tmp/test_env.yaml TF_VAR_port_run_id=run123 terraform validate`

------
https://chatgpt.com/codex/tasks/task_e_689ef8ba3d5c83308216b769497cb1ca