### PR TITLE
Sanitize storage container naming in workflows

### DIFF
--- a/.github/workflows/associate-service.yml
+++ b/.github/workflows/associate-service.yml
@@ -51,6 +51,11 @@ jobs:
           echo "LOCATION=$LOCATION" >> $GITHUB_ENV
           echo "ENV_SHORT_NAME=$ENV_SHORT_NAME" >> $GITHUB_ENV
 
+      - name: Set storage container name
+        run: |
+          CONTAINER_NAME=$(echo "${ENV_SHORT_NAME}${ENVIRONMENT}${LOCATION}" | tr '[:upper:]' '[:lower:]' | tr ' _' '-')
+          echo "CONTAINER_NAME=$CONTAINER_NAME" >> $GITHUB_ENV
+
       - name: Start run
         uses: port-labs/port-github-action@v1
         with:
@@ -112,7 +117,7 @@ jobs:
           terraform -chdir=terraform init \
             -backend-config="resource_group_name=v1vhm-rg-vending-prod-uks-001" \
             -backend-config="storage_account_name=vendingtfstate" \
-            -backend-config="container_name=${ENV_SHORT_NAME}${ENVIRONMENT}${LOCATION}" \
+            -backend-config="container_name=${CONTAINER_NAME}" \
             -backend-config="key=${PRODUCT_IDENTIFIER}_${ENVIRONMENT}_${LOCATION}.tfstate" \
             -reconfigure
 

--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -131,10 +131,15 @@ jobs:
           runId: ${{ env.PORT_RUN_ID }}
           logMessage: ${{ steps.create_env_file.outputs.file_content }}
 
+      - name: Set storage container name
+        run: |
+          CONTAINER_NAME=$(echo "${{ inputs.product_short_name }}${{ inputs.environment }}${{ inputs.location }}" | tr '[:upper:]' '[:lower:]' | tr ' _' '-')
+          echo "CONTAINER_NAME=$CONTAINER_NAME" >> $GITHUB_ENV
+
       - name: Create state container
         run: |
           az storage container create \
-            --name ${{ inputs.product_short_name }}${{ inputs.environment }}${{ inputs.location }} \
+            --name $CONTAINER_NAME \
             --account-name vendingtfstate \
             --resource-group v1vhm-rg-vending-prod-uks-001 \
             --auth-mode login
@@ -154,7 +159,7 @@ jobs:
           terraform -chdir=terraform init \
             -backend-config="resource_group_name=v1vhm-rg-vending-prod-uks-001" \
             -backend-config="storage_account_name=vendingtfstate" \
-            -backend-config="container_name=${{ inputs.product_short_name }}${{ inputs.environment }}${{ inputs.location }}" \
+            -backend-config="container_name=${CONTAINER_NAME}" \
             -backend-config="key=${{ inputs.product_identifier }}_${{ inputs.environment }}_${{ inputs.location }}.tfstate" \
             -reconfigure
 


### PR DESCRIPTION
## Summary
- ensure Terraform state container names are lowercase with hyphens
- reuse sanitized container names in provisioning and service association workflows

## Testing
- `yamllint -d '{rules: {line-length: disable, truthy: disable}}' .github/workflows/provision.yml .github/workflows/associate-service.yml`
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`
- `terraform -chdir=terraform fmt -check`


------
https://chatgpt.com/codex/tasks/task_e_689f0b3b3e1083308892b46b87d5dbe2