### PR TITLE
Accept run ID input in associate service workflow

### DIFF
--- a/.github/workflows/associate-service.yml
+++ b/.github/workflows/associate-service.yml
@@ -17,6 +17,9 @@ on:
       port_run_id:
         description: 'Port action run id'
         required: true
+      request_identifier:
+        description: 'Request identifier that triggered this workflow'
+        required: true
 
 jobs:
   associate:
@@ -141,6 +144,21 @@ jobs:
           operation: PATCH_RUN
           runId: ${{ env.PORT_RUN_ID }}
           logMessage: 'Service association complete'
+
+      - name: Update request status
+        if: success()
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: UPSERT
+          blueprint: request
+          identifier: ${{ inputs.request_identifier }}
+          properties: |
+            {
+              "status": "Configuring Service"
+            }
 
       - name: Mark run failure
         if: failure()

--- a/.github/workflows/associate-service.yml
+++ b/.github/workflows/associate-service.yml
@@ -14,6 +14,9 @@ on:
       github_repo:
         description: 'GitHub repository (org/repo)'
         required: true
+      port_run_id:
+        description: 'Port action run id'
+        required: true
 
 jobs:
   associate:
@@ -39,13 +42,12 @@ jobs:
             echo "Environment file not found" >&2
             exit 1
           fi
-          PORT_RUN_ID=$(grep '^port_run_id:' "$ENV_FILE" | awk '{print $2}')
           PRODUCT_IDENTIFIER=$(grep '^product_identifier:' "$ENV_FILE" | awk '{print $2}')
           ENVIRONMENT=$(grep '^environment:' "$ENV_FILE" | awk '{print $2}')
           LOCATION=$(grep '^location:' "$ENV_FILE" | awk '{print $2}')
           ENV_SHORT_NAME=$(grep '^environment_short_name:' "$ENV_FILE" | awk '{print $2}')
-          echo "PORT_RUN_ID=$PORT_RUN_ID" >> $GITHUB_ENV
-          echo "TF_VAR_port_run_id=$PORT_RUN_ID" >> $GITHUB_ENV
+          echo "PORT_RUN_ID=${{ inputs.port_run_id }}" >> $GITHUB_ENV
+          echo "TF_VAR_port_run_id=${{ inputs.port_run_id }}" >> $GITHUB_ENV
           echo "PRODUCT_IDENTIFIER=$PRODUCT_IDENTIFIER" >> $GITHUB_ENV
           echo "ENVIRONMENT=$ENVIRONMENT" >> $GITHUB_ENV
           echo "LOCATION=$LOCATION" >> $GITHUB_ENV
@@ -74,6 +76,7 @@ jobs:
             env_file = os.environ['ENV_FILE']
             service_id = os.environ['SERVICE_ID']
             github_repo = os.environ['GITHUB_REPO']
+            port_run_id = os.environ['PORT_RUN_ID']
             with open(env_file) as f:
                 data = yaml.safe_load(f) or {}
             services = data.get('services', [])
@@ -84,6 +87,7 @@ jobs:
             else:
                 services.append({'service_identifier': service_id, 'github': {'repository': github_repo}})
             data['services'] = services
+            data['port_run_id'] = port_run_id
             with open(env_file, 'w') as f:
                 yaml.dump(data, f, sort_keys=False)
           PY

--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ Run the **Associate Service** workflow to link a service to an environment. It r
 - `service_identifier` – unique service id
 - `github_repo` – repository in `org/repo` format
 - `port_run_id` – Port action run id for this association
+- `request_identifier` – Port request that triggered the workflow
 
 The workflow updates the environment manifest with the service information and replaces the `port_run_id` with the supplied value.
+After a successful run it also updates the request status to `Configuring Service` in Port.
 
 ## Running locally
 ```bash

--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ GitHub organization and repository so that ownership is clear.
 ## Provisioning an environment
 Port invokes the **Provision Environment** workflow with environment details. On success, the workflow provisions the resources and commits the corresponding YAML file to the repository.
 
+## Associating a service
+
+Run the **Associate Service** workflow to link a service to an environment. It requires the following inputs:
+
+- `environment_identifier` – `<productidentifier>_<environment>_<location>`
+- `service_identifier` – unique service id
+- `github_repo` – repository in `org/repo` format
+- `port_run_id` – Port action run id for this association
+
+The workflow updates the environment manifest with the service information and replaces the `port_run_id` with the supplied value.
+
 ## Running locally
 ```bash
 terraform -chdir=terraform init


### PR DESCRIPTION
## Summary
- take port run ID as workflow input instead of reading manifest
- update environment manifest with new run ID when associating services
- document Associate Service workflow inputs

## Testing
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_689f2294536c83309d6c3064a2de26cf