### PR TITLE
Enhance workflow logging for Port runs

### DIFF
--- a/.github/workflows/associate-service.yml
+++ b/.github/workflows/associate-service.yml
@@ -35,7 +35,19 @@ jobs:
       PORT_CLIENT_ID: ${{ secrets.PORT_CLIENT_ID }}
       PORT_CLIENT_SECRET: ${{ secrets.PORT_CLIENT_SECRET }}
       TF_VAR_environment_file: ${{ github.workspace }}/environments/${{ inputs.environment_identifier }}.yaml
+      PORT_RUN_ID: ${{ inputs.port_run_id }}
+      TF_VAR_port_run_id: ${{ inputs.port_run_id }}
     steps:
+      - name: Log start associate
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{ env.PORT_RUN_ID }}
+          logMessage: 'Associating service ${{ inputs.service_identifier }} with ${{ inputs.environment_identifier }} using repo ${{ inputs.github_repo }}'
+
       - uses: actions/checkout@v4
 
       - name: Load environment context
@@ -49,8 +61,6 @@ jobs:
           ENVIRONMENT=$(grep '^environment:' "$ENV_FILE" | awk '{print $2}')
           LOCATION=$(grep '^location:' "$ENV_FILE" | awk '{print $2}')
           ENV_SHORT_NAME=$(grep '^environment_short_name:' "$ENV_FILE" | awk '{print $2}')
-          echo "PORT_RUN_ID=${{ inputs.port_run_id }}" >> $GITHUB_ENV
-          echo "TF_VAR_port_run_id=${{ inputs.port_run_id }}" >> $GITHUB_ENV
           echo "PRODUCT_IDENTIFIER=$PRODUCT_IDENTIFIER" >> $GITHUB_ENV
           echo "ENVIRONMENT=$ENVIRONMENT" >> $GITHUB_ENV
           echo "LOCATION=$LOCATION" >> $GITHUB_ENV
@@ -60,16 +70,6 @@ jobs:
         run: |
           CONTAINER_NAME=$(echo "${ENV_SHORT_NAME}${ENVIRONMENT}${LOCATION}" | tr '[:upper:]' '[:lower:]' | tr ' _' '-')
           echo "CONTAINER_NAME=$CONTAINER_NAME" >> $GITHUB_ENV
-
-      - name: Start run
-        uses: port-labs/port-github-action@v1
-        with:
-          clientId: ${{ secrets.PORT_CLIENT_ID }}
-          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
-          baseUrl: https://api.getport.io
-          operation: PATCH_RUN
-          runId: ${{ env.PORT_RUN_ID }}
-          logMessage: 'Service association started'
 
       - name: Update services list
         run: |
@@ -129,21 +129,26 @@ jobs:
             -reconfigure
 
       - name: Terraform Plan
-        run: terraform -chdir=terraform plan -no-color
+        id: plan
+        run: |
+          set +e
+          terraform -chdir=terraform plan -no-color 2>&1 | tee plan.log
+          status=$?
+          echo "log<<EOF" >> $GITHUB_OUTPUT
+          cat plan.log >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          exit $status
 
       - name: Terraform Apply (update Port relations)
-        run: terraform -chdir=terraform apply -auto-approve -no-color
-
-      - name: Mark run success
-        if: success()
-        uses: port-labs/port-github-action@v1
-        with:
-          clientId: ${{ secrets.PORT_CLIENT_ID }}
-          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
-          baseUrl: https://api.getport.io
-          operation: PATCH_RUN
-          runId: ${{ env.PORT_RUN_ID }}
-          logMessage: 'Service association complete'
+        id: apply
+        run: |
+          set +e
+          terraform -chdir=terraform apply -auto-approve -no-color 2>&1 | tee apply.log
+          status=$?
+          echo "log<<EOF" >> $GITHUB_OUTPUT
+          cat apply.log >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          exit $status
 
       - name: Update request status
         if: success()
@@ -160,7 +165,18 @@ jobs:
               "status": "Configuring Service"
             }
 
-      - name: Mark run failure
+      - name: Log association complete
+        if: success()
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{ env.PORT_RUN_ID }}
+          logMessage: 'Service association complete for ${{ inputs.service_identifier }} in ${{ inputs.environment_identifier }}'
+
+      - name: Log association failure
         if: failure()
         uses: port-labs/port-github-action@v1
         with:
@@ -170,4 +186,4 @@ jobs:
           operation: PATCH_RUN
           runId: ${{ env.PORT_RUN_ID }}
           status: FAILURE
-          logMessage: 'Service association failed'
+          logMessage: "Associate stage failed: plan=${{ steps.plan.outputs.log }} apply=${{ steps.apply.outputs.log }}"

--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -130,8 +130,8 @@ jobs:
             --account-name vendingtfstate \
             --resource-group v1vhm-rg-vending-prod-uks-001 \
             --auth-mode login
-
       - name: Log preparation complete
+        if: success()
         uses: port-labs/port-github-action@v1
         with:
           clientId: ${{ secrets.PORT_CLIENT_ID }}
@@ -140,6 +140,18 @@ jobs:
           operation: PATCH_RUN
           runId: ${{ env.PORT_RUN_ID }}
           logMessage: 'Prepared ${{ steps.create_env_file.outputs.path }} and container ${{ steps.compute_container.outputs.name }}'
+
+      - name: Log preparation failure
+        if: failure()
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{ env.PORT_RUN_ID }}
+          status: FAILURE
+          logMessage: 'Preparation stage failed for ${{ inputs.product_name }} in ${{ inputs.location }} (${{ inputs.environment }})'
 
   plan:
     needs: prepare
@@ -162,6 +174,16 @@ jobs:
       plan_path: ${{ steps.plan.outputs.path }}
       plan_summary: ${{ steps.summarize.outputs.summary }}
     steps:
+      - name: Log start plan
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{ env.PORT_RUN_ID }}
+          logMessage: 'Starting plan stage for ${{ inputs.product_name }} in ${{ inputs.location }} (${{ inputs.environment }})'
+
       - uses: actions/checkout@v4
 
       - uses: actions/download-artifact@v4
@@ -181,16 +203,6 @@ jobs:
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
 
-      - name: Log start terraform plan
-        uses: port-labs/port-github-action@v1
-        with:
-          clientId: ${{ secrets.PORT_CLIENT_ID }}
-          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
-          baseUrl: https://api.getport.io
-          operation: PATCH_RUN
-          runId: ${{ env.PORT_RUN_ID }}
-          logMessage: 'Starting Terraform Plan for ${{ inputs.product_name }} in ${{ inputs.location }} (${{ inputs.environment }})'
-
       - name: Terraform Init
         run: |
           terraform -chdir=terraform init \
@@ -203,8 +215,14 @@ jobs:
       - name: Terraform Plan
         id: plan
         run: |
-          terraform -chdir=terraform plan -out=tfplan -no-color
+          set +e
+          terraform -chdir=terraform plan -out=tfplan -no-color 2>&1 | tee plan.log
+          status=$?
+          echo "log<<EOF" >> $GITHUB_OUTPUT
+          cat plan.log >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
           echo "path=tfplan" >> $GITHUB_OUTPUT
+          exit $status
 
       - name: Summarize Plan
         id: summarize
@@ -242,7 +260,7 @@ jobs:
           operation: PATCH_RUN
           runId: ${{ env.PORT_RUN_ID }}
           status: FAILURE
-          logMessage: 'Terraform plan failed'
+          logMessage: "Plan stage failed: ${{ steps.plan.outputs.log }}"
 
   apply:
     needs: [prepare, plan]
@@ -267,6 +285,16 @@ jobs:
       azure_subscription: ${{ steps.capture_outputs.outputs.azure_subscription }}
       state_file_container: ${{ steps.capture_outputs.outputs.state_file_container }}
     steps:
+      - name: Log start apply
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{ env.PORT_RUN_ID }}
+          logMessage: 'Starting apply stage for ${{ inputs.product_name }} in ${{ inputs.location }} (${{ inputs.environment }})'
+
       - uses: actions/checkout@v4
 
       - uses: actions/download-artifact@v4
@@ -333,10 +361,13 @@ jobs:
       - name: Terraform Apply
         id: apply
         run: |
-          terraform -chdir=terraform apply -auto-approve -no-color tfplan > apply.log
+          set +e
+          terraform -chdir=terraform apply -auto-approve -no-color tfplan 2>&1 | tee apply.log
+          status=$?
           echo "apply<<EOF" >> $GITHUB_OUTPUT
           cat apply.log >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+          exit $status
 
       - name: Log apply output
         uses: port-labs/port-github-action@v1
@@ -371,7 +402,10 @@ jobs:
           baseUrl: https://api.getport.io
           operation: PATCH_RUN
           runId: ${{ env.PORT_RUN_ID }}
-          logMessage: 'Terraform apply complete'
+          logMessage: >-
+            Terraform apply complete for env=${{ steps.capture_outputs.outputs.deployment_environment }},
+            identity=${{ steps.capture_outputs.outputs.deployment_identity }},
+            subscription=${{ steps.capture_outputs.outputs.azure_subscription }}
 
       - name: Mark apply failure
         if: failure()
@@ -383,7 +417,7 @@ jobs:
           operation: PATCH_RUN
           runId: ${{ env.PORT_RUN_ID }}
           status: FAILURE
-          logMessage: 'Terraform apply failed'
+          logMessage: "Apply stage failed: ${{ steps.apply.outputs.apply }}"
 
   finalize:
     needs: apply
@@ -396,12 +430,6 @@ jobs:
       PORT_CLIENT_SECRET: ${{ secrets.PORT_CLIENT_SECRET }}
       ENV_FILE: environments/${{ inputs.product_short_name }}_${{ inputs.environment }}_${{ inputs.location }}.yaml
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: environment-file
-
       - name: Log start finalize
         uses: port-labs/port-github-action@v1
         with:
@@ -414,6 +442,12 @@ jobs:
             Finalizing ${{ env.ENV_FILE }} with env=${{ needs.apply.outputs.deployment_environment }},
             identity=${{ needs.apply.outputs.deployment_identity }},
             subscription=${{ needs.apply.outputs.azure_subscription }}
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: environment-file
 
       - name: Append outputs to environment file
         run: |
@@ -435,6 +469,7 @@ jobs:
           echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Log finalize completion
+        if: success()
         uses: port-labs/port-github-action@v1
         with:
           clientId: ${{ secrets.PORT_CLIENT_ID }}
@@ -457,4 +492,4 @@ jobs:
           operation: PATCH_RUN
           runId: ${{ env.PORT_RUN_ID }}
           status: FAILURE
-          logMessage: 'Finalize step failed'
+          logMessage: "Finalize stage failed for ${{ env.ENV_FILE }}"


### PR DESCRIPTION
## Summary
- add start, success and failure logging to all workflow jobs
- capture plan/apply output for detailed failure messages
- expose Port run ID in workflow environments

## Testing
- `yamllint .github/workflows/provision.yml .github/workflows/associate-service.yml` *(fails: line too long errors)*
- `yamllint .github/workflows/associate-service.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a1c093c3ec833087bf14c1e8285b92