### PR TITLE
Ensure environment file placed in environments directory after artifact download

### DIFF
--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -190,6 +190,12 @@ jobs:
         with:
           name: environment-file
 
+      - name: Move environment file
+        run: mv $(basename ${{ needs.prepare.outputs.environment_file }}) ${{ needs.prepare.outputs.environment_file }}
+
+      - name: Verify environment file
+        run: test -f "$TF_VAR_environment_file"
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
 
@@ -300,6 +306,12 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: environment-file
+
+      - name: Move environment file
+        run: mv $(basename ${{ needs.prepare.outputs.environment_file }}) ${{ needs.prepare.outputs.environment_file }}
+
+      - name: Verify environment file
+        run: test -f "$TF_VAR_environment_file"
 
       - uses: actions/download-artifact@v4
         with:
@@ -448,6 +460,12 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: environment-file
+
+      - name: Move environment file
+        run: mv $(basename "$ENV_FILE") "$ENV_FILE"
+
+      - name: Verify environment file
+        run: test -f "$ENV_FILE"
 
       - name: Append outputs to environment file
         run: |


### PR DESCRIPTION
## Summary
- move downloaded environment file into `environments/` before Terraform runs
- verify the environment file exists for plan, apply and finalize stages

## Testing
- `yamllint -d '{extends: default, rules: {line-length: disable}}' .github/workflows/provision.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a1c6f8a1c88330a0f4719a958e2cb3