### PR TITLE
refactor workflow error handling

### DIFF
--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -220,17 +220,10 @@ jobs:
 
       - name: Terraform Plan
         id: plan
-        run: |
-          set +e
-          terraform -chdir=terraform plan -out=tfplan -no-color 2>&1 | tee plan.log
-          status=$?
-          echo "log<<EOF" >> $GITHUB_OUTPUT
-          cat plan.log >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-          echo "path=tfplan" >> $GITHUB_OUTPUT
-          exit $status
+        run: ./scripts/terraform-run.sh plan tfplan plan.log
 
       - name: Summarize Plan
+        if: success()
         id: summarize
         run: |
           terraform -chdir=terraform show -json tfplan | jq -r '.resource_changes[] | "- " + .address + ": " + (.change.actions|join(", "))' > plan_summary.txt
@@ -240,6 +233,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Upload plan
+        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: tfplan
@@ -372,16 +366,10 @@ jobs:
 
       - name: Terraform Apply
         id: apply
-        run: |
-          set +e
-          terraform -chdir=terraform apply -auto-approve -no-color tfplan 2>&1 | tee apply.log
-          status=$?
-          echo "apply<<EOF" >> $GITHUB_OUTPUT
-          cat apply.log >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-          exit $status
+        run: ./scripts/terraform-run.sh apply tfplan apply.log
 
       - name: Log apply output
+        if: success()
         uses: port-labs/port-github-action@v1
         with:
           clientId: ${{ secrets.PORT_CLIENT_ID }}
@@ -389,7 +377,7 @@ jobs:
           baseUrl: https://api.getport.io
           operation: PATCH_RUN
           runId: ${{ env.PORT_RUN_ID }}
-          logMessage: ${{ steps.apply.outputs.apply }}
+          logMessage: ${{ steps.apply.outputs.log }}
 
       - name: Capture outputs
         id: capture_outputs
@@ -429,7 +417,7 @@ jobs:
           operation: PATCH_RUN
           runId: ${{ env.PORT_RUN_ID }}
           status: FAILURE
-          logMessage: "Apply stage failed: ${{ steps.apply.outputs.apply }}"
+          logMessage: "Apply stage failed: ${{ steps.apply.outputs.log }}"
 
   finalize:
     needs: apply
@@ -479,12 +467,24 @@ jobs:
       - name: Commit updated environment file
         id: commit
         run: |
+          set -euo pipefail
+          finish() {
+            status=$?
+            echo "log<<EOF" >> "$GITHUB_OUTPUT"
+            cat commit.log >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+            exit $status
+          }
+          trap finish ERR
+          exec > >(tee commit.log) 2>&1
           git config user.email "75343302+getport-io[bot]@users.noreply.github.com"
           git config user.name "getport-io[bot]"
           git add $ENV_FILE
           git commit -m "Update product environment ${{ inputs.product_short_name }}_${{ inputs.environment }}_${{ inputs.location }} with outputs"
           git push origin HEAD:main
-          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          trap - ERR
+          finish
 
       - name: Log finalize completion
         if: success()
@@ -510,4 +510,4 @@ jobs:
           operation: PATCH_RUN
           runId: ${{ env.PORT_RUN_ID }}
           status: FAILURE
-          logMessage: "Finalize stage failed for ${{ env.ENV_FILE }}"
+          logMessage: "Finalize stage failed: ${{ steps.commit.outputs.log }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,12 @@ When editing `.github/workflows/provision.yml` or adding new workflows:
 5. **Logging to Port:** Many steps call `port-labs/port-github-action` to log messages or mark run status.  If you add new steps that perform long‑running tasks, consider adding a corresponding log entry so that Port users can follow progress.
 6. **File paths for Terraform:** Terraform commands run with `-chdir=terraform`. When passing file paths (e.g., the environment YAML) via variables, supply an absolute path so Terraform can locate the file regardless of the current working directory.
 
+### Error handling
+
+Terraform execution in the provisioning workflow is centralized in `scripts/terraform-run.sh`. This helper uses `set -euo pipefail` and a `trap` handler to capture the exit code and emit the collected log back to the step through `$GITHUB_OUTPUT`. Invoke it for Terraform `plan` and `apply` to ensure consistent logging.
+
+Workflow steps that depend on previous steps should explicitly set `if: success()` (e.g., summarizing or uploading the plan). Logging steps that surface errors should use `if: failure()` and reference the failing step's output such as `${{ steps.plan.outputs.log }}` so that problems are visible in Port.
+
 ## Updating Terraform
 
 * **Variables and modules:** When adding new fields to the environment YAML schema (e.g., a new tag or property), declare a corresponding variable in `terraform/modules/resource_group/variables.tf` and propagate it through `terraform/main.tf` into the module and resources.  Be consistent: if a variable is optional, give it a default value or use `try()` in the module to avoid errors.

--- a/scripts/terraform-run.sh
+++ b/scripts/terraform-run.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cmd=$1
+plan_file=$2
+log_file=$3
+
+finish() {
+  status=$?
+  echo "log<<EOF" >> "$GITHUB_OUTPUT"
+  cat "$log_file" >> "$GITHUB_OUTPUT"
+  echo "EOF" >> "$GITHUB_OUTPUT"
+  exit $status
+}
+trap finish ERR
+
+if [ "$cmd" = "plan" ]; then
+  terraform -chdir=terraform plan -out="$plan_file" -no-color 2>&1 | tee "$log_file"
+  echo "path=$plan_file" >> "$GITHUB_OUTPUT"
+elif [ "$cmd" = "apply" ]; then
+  terraform -chdir=terraform apply -auto-approve -no-color "$plan_file" 2>&1 | tee "$log_file"
+else
+  echo "Unsupported command: $cmd" >&2
+  exit 1
+fi
+
+trap - ERR
+finish


### PR DESCRIPTION
## Summary
- use a helper script for Terraform execution with trap-based logging
- guard plan artifacts behind `if: success()`
- surface failure logs for finalize step

## Testing
- `bash -n scripts/terraform-run.sh`
- `cd terraform && terraform fmt -check -recursive && cd ..`


------
https://chatgpt.com/codex/tasks/task_e_68a1cc84f3708330ba2aacf8547fa672