### PR TITLE
Link state containers to storage accounts

### DIFF
--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -147,6 +147,8 @@ jobs:
           blueprint: azureStorageContainer
           identifier: ${{ env.STATE_FILE_CONTAINER_ID }}
           title: ${{ env.CONTAINER_NAME }}
+          relations: >-
+            storageAccount: "/subscriptions/${{ env.ARM_SUBSCRIPTION_ID }}/resourceGroups/v1vhm-rg-vending-prod-uks-001/providers/Microsoft.Storage/storageAccounts/vendingtfstate"
       - name: Log preparation complete
         if: success()
         uses: port-labs/port-github-action@v1

--- a/terraform/modules/resource_group/main.tf
+++ b/terraform/modules/resource_group/main.tf
@@ -110,9 +110,7 @@ resource "port_entity" "state_container" {
   identifier = lower("${azurerm_storage_account.sa.name}-tfstate")
   title      = azurerm_storage_container.tfstate.name
   relations = {
-    single_relations = {
-      storageAccount = lower(port_entity.storage_account.identifier)
-    }
+    storageAccount = azurerm_storage_account.sa.id
   }
   run_id = var.port_run_id
 }


### PR DESCRIPTION
## Summary
- associate state container Port entities with their storage account
- set workflow to record storage account relation

## Testing
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_68a1db4400a08330890bdf2876f0d294