### PR TITLE
Use JSON strings for Port action fields

### DIFF
--- a/.github/workflows/associate-service.yml
+++ b/.github/workflows/associate-service.yml
@@ -160,10 +160,8 @@ jobs:
           operation: UPSERT
           blueprint: request
           identifier: ${{ inputs.request_identifier }}
-          properties: |
-            {
-              "status": "Configuring Service"
-            }
+          properties: >-
+            {"status": "Configuring Service"}
 
       - name: Log association complete
         if: success()

--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -137,7 +137,7 @@ jobs:
           STATE_FILE_CONTAINER_ID=$(echo "vendingtfstate-${CONTAINER_NAME}" | tr '[:upper:]' '[:lower:]')
           echo "STATE_FILE_CONTAINER_ID=$STATE_FILE_CONTAINER_ID" >> $GITHUB_ENV
           echo "id=$STATE_FILE_CONTAINER_ID" >> $GITHUB_OUTPUT
-      - name: Register state container
+      - name: Upsert state container
         uses: port-labs/port-github-action@v1
         with:
           clientId: ${{ secrets.PORT_CLIENT_ID }}
@@ -148,7 +148,8 @@ jobs:
           identifier: ${{ env.STATE_FILE_CONTAINER_ID }}
           title: ${{ env.CONTAINER_NAME }}
           relations: >-
-            storageAccount: "/subscriptions/${{ env.ARM_SUBSCRIPTION_ID }}/resourceGroups/v1vhm-rg-vending-prod-uks-001/providers/Microsoft.Storage/storageAccounts/vendingtfstate"
+            {"storageAccount": "/subscriptions/${{ env.ARM_SUBSCRIPTION_ID }}/resourceGroups/v1vhm-rg-vending-prod-uks-001/providers/Microsoft.Storage/storageAccounts/vendingtfstate"}
+          properties: '{}'
       - name: Log preparation complete
         if: success()
         uses: port-labs/port-github-action@v1


### PR DESCRIPTION
## Summary
- encode Port "Upsert state container" step with JSON-style relations/properties
- use JSON string for request status update

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 200}}}' .github/workflows/provision.yml .github/workflows/associate-service.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a25187279c8330ada31e049473c697