### PR TITLE
Lowercase storage account relation for state container

### DIFF
--- a/terraform/modules/resource_group/main.tf
+++ b/terraform/modules/resource_group/main.tf
@@ -110,7 +110,7 @@ resource "port_entity" "state_container" {
   identifier = lower("${azurerm_storage_account.sa.name}-tfstate")
   title      = azurerm_storage_container.tfstate.name
   relations = {
-    storageAccount = azurerm_storage_account.sa.id
+    storageAccount = lower(azurerm_storage_account.sa.id)
   }
   run_id = var.port_run_id
 }


### PR DESCRIPTION
## Summary
- ensure state container relation uses a lowercased storage account ID

## Testing
- `terraform fmt -recursive`
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_68a253a402c48330a28b27ddae934807