### PR TITLE
Document lowercase Azure resource IDs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ The high‑level layout is:
 * **Terraform state:** A recent change introduced a separate state file per environment (see commit message *"Create a new state file for each environment"*).  If adding new environments or modifying the backend configuration, keep this behaviour by using a unique `key` in `backend.tf` (e.g., `${product_identifier}_${environment}_${location}.tfstate`).  Avoid using a single shared `terraform.tfstate` for all environments.
 * **Port entities:** The Terraform root registers a Port *environment* entity using the `product_identifier`, environment tier and location as the identifier and title.  Do not revert to using the short name here; a recent commit corrected this (see commit *"port objects now use correct identifier"*).  When adding properties or relations to Port entities, ensure that identifiers remain stable (changing them will orphan existing records).  Services relate to this entity through the optional `services` list.
 * **Use IDs for relations:** Another recent change switched from using resource names to Azure IDs when passing values back to Port (see commit *"Changing resource name properties to id properties"*).  When adding new outputs or relations, prefer IDs over names; IDs are globally unique and avoid collisions.
+* **Lowercase resource IDs:** Convert any Azure resource ID passed to Port to lowercase to ensure consistency.
 
 ## Making changes to the workflow
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ The `product_name` and `product_identifier` fields record the owning product. Se
 
 Managed identities and federated credentials are created automatically by Terraform. The identity is granted Owner access to the resource group and Storage Blob Data Contributor access to the storage account. The resource group is tagged with the environment, product identifier and product name, GitHub organization and repository so that ownership is clear.
 
+## Conventions
+
+All Azure resource IDs referenced in environment files or Port relations must be lowercase.
+
 ## Provisioning an environment
 Port invokes the **Provision Environment** workflow with environment details. On success, the workflow provisions the resources and commits the corresponding YAML file to the repository.
 


### PR DESCRIPTION
## Summary
- clarify that Azure resource IDs passed to Port must be lowercase
- note lowercase requirement for resource IDs in environment files and Port relations

## Testing
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_68a25499de148330a3a587d0c8ab7e25