### PR TITLE
Document workflow status tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ environment_identifier: demo_product_dev_eastus
 environment_title: Demo Product dev
 location: eastus
 environment: dev               # dev | test | prod | acct
+status: in_progress        # then succeeded | failed
 port_run_id: abcde12345       # Port action run id
 product_name: Demo Product
 product_identifier: prod-12345     # product identifier from Port
@@ -18,7 +19,7 @@ deployment_identity: /subscriptions/.../providers/Microsoft.ManagedIdentity/user
 azure_subscription: /subscriptions/...      # subscription id
 state_file_container: /subscriptions/.../storageAccounts/vendingtfstate/blobServices/default/containers/prod-12345dev
 ```
-The `product_name` and `product_identifier` fields record the owning product. Services are associated with an environment later, so `services` may be omitted or left as an empty list. The fields `deployment_environment`, `deployment_identity`, `azure_subscription` and `state_file_container` are appended after provisioning and are used to create the Port environment entity outside of Terraform.
+The `status` line records the workflow's progress: it starts as `in_progress` and is later set to `succeeded` or `failed`. The `product_name` and `product_identifier` fields record the owning product. Services are associated with an environment later, so `services` may be omitted or left as an empty list. The fields `deployment_environment`, `deployment_identity`, `azure_subscription` and `state_file_container` are appended after provisioning and are used to create the Port environment entity outside of Terraform. The file is committed when created, updated with outputs and finalized with the workflow result.
 
 Managed identities and federated credentials are created automatically by Terraform. The identity is granted Owner access to the resource group and Storage Blob Data Contributor access to the storage account. The resource group is tagged with the environment, product identifier and product name, GitHub organization and repository so that ownership is clear.
 
@@ -27,7 +28,7 @@ Managed identities and federated credentials are created automatically by Terraf
 All Azure resource IDs referenced in environment files or Port relations must be lowercase.
 
 ## Provisioning an environment
-Port invokes the **Provision Environment** workflow with environment details. On success, the workflow provisions the resources and commits the corresponding YAML file to the repository.
+Port invokes the **Provision Environment** workflow with environment details. The workflow writes the environment file and commits it immediately so that subsequent jobs read the committed file rather than workflow artifacts. On success, the workflow provisions the resources and updates the same file with outputs and a final status.
 
 ## Associating a service
 


### PR DESCRIPTION
## Summary
- clarify how the environment manifest tracks workflow progress with a `status` field
- document commit/update sequence for the environment file
- note that jobs read the committed manifest rather than artifacts

## Testing
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`
- `terraform -chdir=terraform fmt -check`


------
https://chatgpt.com/codex/tasks/task_e_68a35d6370d48330a91fa989875fedc9