### PR TITLE
Add dependency on user-managed identity for Port entity

### DIFF
--- a/terraform/modules/resource_group/main.tf
+++ b/terraform/modules/resource_group/main.tf
@@ -132,6 +132,8 @@ resource "port_entity" "user_managed_identity" {
   }
 
   run_id = var.port_run_id
+
+  depends_on = [azurerm_user_assigned_identity.uai]
 }
 
 output "resource_group_id" {


### PR DESCRIPTION
## Summary
- ensure Port entity for the user-managed identity waits for the identity to be created

## Testing
- `terraform -chdir=terraform fmt -recursive`
- `terraform -chdir=terraform init` (fails: One of `access_key`, `sas_token`, `use_azuread_auth` and `resource_group_name` must be specified)
- `terraform -chdir=terraform apply -auto-approve` (fails: Backend initialization required)


------
https://chatgpt.com/codex/tasks/task_e_68a37be2263883309ac361427876c46e