### PR TITLE
Expose user managed identity client ID

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -54,3 +54,7 @@ output "state_file_container" {
   value = module.environment.state_file_container
 }
 
+output "user_managed_identity_client_id" {
+  value = module.environment.user_managed_identity_client_id
+}
+

--- a/terraform/modules/resource_group/main.tf
+++ b/terraform/modules/resource_group/main.tf
@@ -151,3 +151,7 @@ output "user_managed_identity_id" {
 output "state_file_container" {
   value = port_entity.state_container.identifier
 }
+
+output "user_managed_identity_client_id" {
+  value = azurerm_user_assigned_identity.uai.client_id
+}


### PR DESCRIPTION
## Summary
- output user managed identity client ID from resource group module
- expose user managed identity client ID at root level

## Testing
- `terraform init` *(fails: One of `access_key`, `sas_token`, `use_azuread_auth` and `resource_group_name` must be specifieid)*
- `terraform apply -auto-approve` *(fails: Backend initialization required)*
- `terraform output user_managed_identity_client_id` *(fails: Backend initialization required)*

------
https://chatgpt.com/codex/tasks/task_e_68a37e0f88a88330a6ab27cd3dbdc4c8