### PR TITLE
Add precondition for user-managed identity client ID

### DIFF
--- a/terraform/modules/resource_group/main.tf
+++ b/terraform/modules/resource_group/main.tf
@@ -134,6 +134,13 @@ resource "port_entity" "user_managed_identity" {
   run_id = var.port_run_id
 
   depends_on = [azurerm_user_assigned_identity.uai]
+
+  lifecycle {
+    precondition {
+      condition     = length(azurerm_user_assigned_identity.uai.client_id) > 0
+      error_message = "azurerm_user_assigned_identity.uai.client_id is empty"
+    }
+  }
 }
 
 output "resource_group_id" {


### PR DESCRIPTION
## Summary
- add lifecycle precondition to ensure user managed identity's client ID is not empty

## Testing
- `terraform -chdir=terraform/modules/resource_group init -backend=false`
- `terraform -chdir=terraform/modules/resource_group validate`
- `terraform -chdir=terraform apply -auto-approve -var environment_file=environments/TESTPR_dev_ukwest.yaml -var port_run_id=test-run` *(fails: Backend initialization required)*

------
https://chatgpt.com/codex/tasks/task_e_68a37e11a10883309db687559b480b79