### PR TITLE
Support Terraform debug logs

### DIFF
--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -248,6 +248,7 @@ jobs:
             -backend-config="key=${{ inputs.product_identifier }}_${{ inputs.environment }}_${{ inputs.location }}.tfstate" \
             -reconfigure
 
+      # Set TF_LOG_LEVEL (e.g., TRACE) to capture detailed Terraform logs
       - name: Terraform Plan
         id: plan
         run: ./scripts/terraform-run.sh plan tfplan plan.log
@@ -378,6 +379,7 @@ jobs:
           runId: ${{ env.PORT_RUN_ID }}
           logMessage: 'Starting Terraform Apply'
 
+      # Set TF_LOG_LEVEL (e.g., TRACE) to capture detailed Terraform logs
       - name: Terraform Apply
         id: apply
         run: ./scripts/terraform-run.sh apply tfplan apply.log

--- a/scripts/terraform-run.sh
+++ b/scripts/terraform-run.sh
@@ -5,11 +5,18 @@ cmd=$1
 plan_file=$2
 log_file=$3
 
+if [[ -n "${TF_LOG_LEVEL:-}" ]]; then
+  export TF_LOG="$TF_LOG_LEVEL"
+  export TF_LOG_PATH="$log_file"
+fi
+
 finish() {
   status=$?
-  echo "log<<EOF" >> "$GITHUB_OUTPUT"
-  cat "$log_file" >> "$GITHUB_OUTPUT"
-  echo "EOF" >> "$GITHUB_OUTPUT"
+  {
+    echo "log<<EOF"
+    cat "$log_file"
+    echo "EOF"
+  } >> "$GITHUB_OUTPUT"
   exit $status
 }
 trap finish ERR


### PR DESCRIPTION
## Summary
- allow terraform-run.sh to honor TF_LOG_LEVEL and emit logs to file
- document TF_LOG_LEVEL in provisioning workflow for optional debugging

## Testing
- `bash -n scripts/terraform-run.sh`
- `shellcheck scripts/terraform-run.sh`
- `actionlint -ignore SC2086 -ignore SC2129 .github/workflows/provision.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a37e157d3c8330927b6dc7af43caea