### PR TITLE
Upsert managed identity client ID after apply

### DIFF
--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -405,8 +405,10 @@ jobs:
 
       - name: Capture outputs
         run: |
+          set -euo pipefail
+          IFS=$'\n\t'
           terraform -chdir=terraform output -json > tfoutput.json
-          for key in deployment_environment deployment_identity azure_subscription state_file_container; do
+          for key in deployment_environment deployment_identity azure_subscription state_file_container user_managed_identity_client_id; do
             value=$(jq -r ".${key}.value" tfoutput.json)
             varname=$(echo "$key" | tr '[:lower:]' '[:upper:]')
             echo "${varname}=$value" >> "$GITHUB_ENV"
@@ -435,6 +437,19 @@ jobs:
           git commit -m "Update environment ${{ inputs.product_short_name }}_${{ inputs.environment }}_${{ inputs.location }} with outputs"
           git push origin HEAD:main
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Upsert managed identity clientId
+        if: success()
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: UPSERT
+          blueprint: azureUserManagedIdentity
+          identifier: ${{ env.DEPLOYMENT_IDENTITY }}
+          properties: >-
+            {"clientId": "${{ env.USER_MANAGED_IDENTITY_CLIENT_ID }}"}
 
       - name: Mark apply success
         if: success()


### PR DESCRIPTION
## Summary
- capture managed identity client ID from Terraform outputs
- upsert the managed identity's clientId to Port after successful apply

## Testing
- `./actionlint .github/workflows/provision.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a37b4cc69c8330b6e6e3ce2eb2a673