### PR TITLE
Remove Port entities and run ID from Terraform module

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -20,26 +20,3 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
-
-provider "registry.terraform.io/port-labs/port-labs" {
-  version     = "2.13.0"
-  constraints = "~> 2.0"
-  hashes = [
-    "h1:E4wks8eWTMPb6wl7ix/wpm0tmZNMHAbi5/yiXnDhkMg=",
-    "zh:00b7ed5fac9ec8909b46938bc401ded3588598d4afcc5e0e4a8847fa08848cc3",
-    "zh:0fd57eff30ac0a813e900cdef4e7ea9f2ef037c7a6544340b2812b00640bd06f",
-    "zh:1566265ceec8e0ade0c4e945e53278e14af7ae8cf361e93fd0d56c7744d13e54",
-    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
-    "zh:1f7b5471d0ff40dba0fe2bd72879837502ab417250f5315c992a1d2eae4f733a",
-    "zh:53e2332ee50ad86b6631283e12a675f73d3cf9e834216e7e9450f1d7e43f4aeb",
-    "zh:5bd2ecbebbb141187ad2c2db71da228ce418cbad27c2406aae057a8062f99a01",
-    "zh:70c3babe1ffe77ca2f7cfc2e14d0636113e4acf8db65523e2e949ef31d6a91c3",
-    "zh:8e9d7e6a5d76a34e647239b9cd8be9018e56171e6cd53925c4f866f13787d0ff",
-    "zh:8fafc30e7a0515511dc86ee4592603993de35a2fb55659026d36806680651d62",
-    "zh:bdba9da5e13c8af08a51f0e9c207c946bdbe6b9d115ad22d83e68ea2d1112894",
-    "zh:c2feff3488e4b3f614ba4b0ca5c3b87b2da05b032f7fa1424d2b4968faf43e4f",
-    "zh:c7d5cae7a7def1b4b09d58038263d27d1ba4b2fe23418fd61f839fdcc6178c33",
-    "zh:dd903032c2f5f385d86be06025bdb8ef57805061af5612669237817ef1a7024c",
-    "zh:f6c4148a2ca395278951d4e224456b037dbf4ea6d6f6f0be2dfe6ead2f6e05e4",
-  ]
-}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,18 +5,12 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.0"
     }
-    port = {
-      source  = "port-labs/port-labs"
-      version = "~> 2"
-    }
   }
 }
 
 provider "azurerm" {
   features {}
 }
-
-provider "port" {}
 
 data "azurerm_subscription" "current" {}
 
@@ -35,7 +29,6 @@ module "environment" {
   product_name       = local.product_name
   product_identifier = local.product_identifier
   services           = local.services
-  port_run_id        = var.port_run_id
 }
 
 output "deployment_environment" {

--- a/terraform/modules/resource_group/variables.tf
+++ b/terraform/modules/resource_group/variables.tf
@@ -14,4 +14,3 @@ variable "services" {
   }))
   default = []
 }
-variable "port_run_id" { type = string }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,7 +1,3 @@
-variable "port_run_id" {
-  type = string
-}
-
 variable "environment_file" {
   type = string
 }


### PR DESCRIPTION
## Summary
- drop Port `port_entity` resources and associated run IDs from the resource group module
- remove unused `port_run_id` variable and Port provider configuration
- derive state container output from the Azure storage account

## Testing
- `terraform fmt -recursive`
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_68a384c608e08330b0e877ad989bfed4