### PR TITLE
Reference Port entities in Terraform outputs

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -116,11 +116,11 @@ resource "port_entity" "user_managed_identity" {
 }
 
 output "deployment_environment" {
-  value = module.environment.resource_group_id
+  value = port_entity.resource_group.identifier
 }
 
 output "deployment_identity" {
-  value = module.environment.user_managed_identity_id
+  value = port_entity.user_managed_identity.identifier
 }
 
 output "azure_subscription" {
@@ -128,7 +128,7 @@ output "azure_subscription" {
 }
 
 output "state_file_container" {
-  value = module.environment.state_file_container
+  value = port_entity.state_container.identifier
 }
 
 output "user_managed_identity_client_id" {


### PR DESCRIPTION
## Summary
- Use Port entities for Terraform outputs to expose the resource group, user-managed identity, and state container identifiers
- Outputs continue to surface Azure subscription and identity client ID

## Testing
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_68a38b636d1083308a73ee905ede40ab