### PR TITLE
Handle failure status in associate service workflow

### DIFF
--- a/.github/workflows/associate-service.yml
+++ b/.github/workflows/associate-service.yml
@@ -200,6 +200,19 @@ jobs:
           runId: ${{ env.PORT_RUN_ID }}
           logMessage: 'Service association complete for ${{ inputs.service_identifier }} in ${{ inputs.environment_identifier }}'
 
+      - name: Update request failure status
+        if: failure()
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: UPSERT
+          blueprint: request
+          identifier: ${{ inputs.request_identifier }}
+          properties: >-
+            {"status": "Failed"}
+
       - name: Log association failure
         if: failure()
         uses: port-labs/port-github-action@v1


### PR DESCRIPTION
## Summary
- update associate-service workflow to mark request as failed when job fails

## Testing
- `./actionlint .github/workflows/associate-service.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a4a5e074a483309c3a0de048da0015