### PR TITLE
fix: derive env short name from product identifier

### DIFF
--- a/.github/workflows/associate-service.yml
+++ b/.github/workflows/associate-service.yml
@@ -68,7 +68,7 @@ jobs:
           PRODUCT_IDENTIFIER=$(grep '^product_identifier:' "$ENV_FILE" | awk '{print $2}')
           ENVIRONMENT=$(grep '^environment:' "$ENV_FILE" | awk '{print $2}')
           LOCATION=$(grep '^location:' "$ENV_FILE" | awk '{print $2}')
-          ENV_SHORT_NAME=$(grep '^environment_short_name:' "$ENV_FILE" | awk '{print $2}')
+          ENV_SHORT_NAME=$(echo "$PRODUCT_IDENTIFIER" | tr '[:upper:]' '[:lower:]')
           {
             echo "product_identifier=$PRODUCT_IDENTIFIER"
             echo "environment=$ENVIRONMENT"


### PR DESCRIPTION
## Summary
- derive environment short name from product identifier in associate service workflow

## Testing
- `actionlint .github/workflows/associate-service.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a4d9c1e32c83309ba2401e4c9f4a78