### PR TITLE
Add service containers and federated credentials

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,14 +50,14 @@ Workflow steps that depend on previous steps should explicitly set `if: success(
 * **Variables and modules:** When adding new fields to the environment YAML schema (e.g., a new tag or property), declare a corresponding variable in `terraform/modules/resource_group/variables.tf` and propagate it through `terraform/main.tf` into the module and resources.  Be consistent: if a variable is optional, give it a default value or use `try()` in the module to avoid errors.
 * **Resource naming:** Azure resources have naming rules (storage accounts require globally unique names, 3–24 lowercase alphanumeric characters; resource groups can include alphanumerics, hyphens and underscores).  Resource groups follow the `rg-${var.product_identifier}-${var.environment}-${var.location}` pattern, while storage accounts use `v1vhm${var.product_identifier}${var.environment}${var.location}`.  If you change the naming pattern, ensure it remains valid and update all dependent resources and outputs.
 * **Outputs:** The resource group module exposes detailed attributes for the
-  resource group, storage account, state container and user‑managed identity.
+  resource group, storage account, service containers and user‑managed identity.
   The root configuration consumes these outputs to register Port entities and
   exposes high‑level values (`deployment_environment`, `deployment_identity`,
-  `azure_subscription`, `state_file_container` and
-  `user_managed_identity_client_id`) so the workflow can record them in the
-  environment file.  When adding new outputs, update the workflow step that
-  appends these values (the step uses `jq` to extract them from `terraform
-  output`).  Maintain JSON parsing rather than relying on string matching.
+  `azure_subscription` and `user_managed_identity_client_id`) so the workflow
+  can record them in the environment file.  When adding new outputs, update the
+  workflow step that appends these values (the step uses `jq` to extract them
+  from `terraform output`).  Maintain JSON parsing rather than relying on string
+  matching.
 * **Port integration:** Use the `port_labs` provider in the root configuration
   to register additional entities or relations.  Keep identifiers stable and
   avoid changing blueprint names.  The resource group module does not create
@@ -68,7 +68,7 @@ Workflow steps that depend on previous steps should explicitly set `if: success(
 To add a new environment (for example, a new microservice or a new tier for an existing service):
 
 1. Run the **Provision Environment** workflow manually via the GitHub Actions UI or allow Port to trigger it.  Provide appropriate values for all inputs.  The workflow will create a YAML file under `environments/`, create the state container, run Terraform and commit the YAML file and its updates.
-2. After the workflow completes, verify that the new YAML file exists under `environments/` and that the `deployment_environment`, `deployment_identity`, `azure_subscription` and `state_file_container` entries were appended.
+2. After the workflow completes, verify that the new YAML file exists under `environments/` and that the `deployment_environment`, `deployment_identity` and `azure_subscription` entries were appended.
 3. If services need to be associated, run the dedicated service‑association workflow to populate the `services` list.
 4. Inspect the Azure portal to confirm that the resource group, storage account and user‑managed identity have been created with the expected names.  Ensure tags reflect the environment metadata.
 5. Consider adding unit tests or integration tests (e.g., using `terraform validate` or `terraform plan` in CI) to prevent regressions.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ services: []                       # optional; services can be associated later
 deployment_environment: /subscriptions/.../resourceGroups/rg-prod-12345-dev-eastus
 deployment_identity: /subscriptions/.../providers/Microsoft.ManagedIdentity/userAssignedIdentities/uai-prod-12345-dev-eastus
 azure_subscription: /subscriptions/...      # subscription id
-  state_file_container: v1vhmprod-12345deveastus-tfstate
 ```
-The `status` line records the workflow's progress: it starts as `in_progress` and is later set to `succeeded` or `failed`. The `product_name` and `product_identifier` fields record the owning product. Services are associated with an environment later, so `services` may be omitted or left as an empty list. The fields `deployment_environment`, `deployment_identity`, `azure_subscription` and `state_file_container` are appended after provisioning and are used to create the Port environment entity outside of Terraform. The file is committed when created, updated with outputs and finalized with the workflow result.
+```
+The `status` line records the workflow's progress: it starts as `in_progress` and is later set to `succeeded` or `failed`. The `product_name` and `product_identifier` fields record the owning product. Services are associated with an environment later, so `services` may be omitted or left as an empty list. The fields `deployment_environment`, `deployment_identity` and `azure_subscription` are appended after provisioning and are used to create the Port environment entity outside of Terraform. The file is committed when created, updated with outputs and finalized with the workflow result.
 
 Managed identities and federated credentials are created automatically by Terraform. The identity is granted Owner access to the resource group and Storage Blob Data Contributor access to the storage account. The resource group is tagged with the environment, product identifier and product name, GitHub organization and repository so that ownership is clear.
 
@@ -31,17 +31,17 @@ provisioning Azure infrastructure. The module exposes detailed
 attributes for each resource, including:
 
 - `resource_group_*` values for the resource group
-- `storage_account_*` values and the `state_container_name`/
-  `state_file_container`
+- `storage_account_*` values
+- `service_containers` mapping for per-service storage containers
 - `user_managed_identity_*` values for the identity
 
-`terraform/main.tf` consumes these outputs to register Port entities and
-then returns high‑level values used by the GitHub Actions workflow:
+`terraform/main.tf` consumes these outputs to register Port entities for the
+resource group, storage account, each service container and the user-managed
+identity, then returns high‑level values used by the GitHub Actions workflow:
 
 - `deployment_environment` – the resource group id
 - `deployment_identity` – the user managed identity id
 - `azure_subscription` – the subscription id
-- `state_file_container` – the state container id
 - `user_managed_identity_client_id`
 
 Port entities are created in the root configuration; the module itself

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -90,12 +90,21 @@ resource "port_entity" "storage_account" {
   run_id = var.port_run_id
 }
 
-resource "port_entity" "state_container" {
+resource "port_entity" "service_container" {
+  for_each   = module.environment.service_containers
   blueprint  = "azureStorageContainer"
-  identifier = module.environment.state_file_container
-  title      = module.environment.state_container_name
+  identifier = each.value.id
+  title      = each.value.name
 
-  properties = {}
+  properties = {
+    string_props = {
+      location = module.environment.storage_account_location
+    }
+
+    object_props = {
+      tags = jsonencode(module.environment.resource_group_tags)
+    }
+  }
 
   relations = {
     single_relations = {
@@ -141,10 +150,6 @@ output "deployment_identity" {
 
 output "azure_subscription" {
   value = lower(data.azurerm_subscription.current.id)
-}
-
-output "state_file_container" {
-  value = port_entity.state_container.identifier
 }
 
 output "user_managed_identity_client_id" {

--- a/terraform/modules/resource_group/variables.tf
+++ b/terraform/modules/resource_group/variables.tf
@@ -6,10 +6,7 @@ variable "services" {
   type = list(object({
     service_identifier = string
     github = object({
-      org         = string
-      repo        = string
-      entity      = string
-      entity_name = string
+      repository = string
     })
   }))
   default = []


### PR DESCRIPTION
## Summary
- redefine services variable with simplified github repository field
- create per-service storage containers and federated identity credentials
- remove legacy state container and associated outputs
- upsert each service's storage container as a Port entity

## Testing
- `terraform -chdir=terraform fmt`
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`
- `terraform -chdir=terraform/modules/resource_group fmt`
- `terraform -chdir=terraform/modules/resource_group init -backend=false`
- `terraform -chdir=terraform/modules/resource_group validate`


------
https://chatgpt.com/codex/tasks/task_e_68a4e27b7ae08330a2c8113797a858b4