### PR TITLE
Use explicit YAML indentation in service association workflow

### DIFF
--- a/.github/workflows/associate-service.yml
+++ b/.github/workflows/associate-service.yml
@@ -110,7 +110,7 @@ jobs:
           data['services'] = services
           data['port_run_id'] = port_run_id
           with open(env_file, 'w') as f:
-              yaml.dump(data, f, sort_keys=False)
+              yaml.dump(data, f, sort_keys=False, default_flow_style=False, indent=2)
           PY
           sed -i 's/^          //' update_service.py
           python update_service.py


### PR DESCRIPTION
## Summary
- dump environment YAML with explicit indentation when associating services

## Testing
- `/root/go/bin/actionlint .github/workflows/associate-service.yml`
- `gh workflow run associate-service.yml -f environment_identifier=testpr_prod_ukwest -f service_identifier=svc -f github_repo=org/repo -f port_run_id=1 -f request_identifier=1` *(fails: To get started with GitHub CLI, please run: gh auth login)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e07b692c8330b61d1af91ac6609a