### PR TITLE
Use dedicated env state container

### DIFF
--- a/.github/workflows/associate-service.yml
+++ b/.github/workflows/associate-service.yml
@@ -39,7 +39,7 @@ jobs:
       environment: ${{ steps.env.outputs.environment }}
       location: ${{ steps.env.outputs.location }}
       env_short_name: ${{ steps.env.outputs.env_short_name }}
-      container_name: ${{ steps.container.outputs.container_name }}
+      env_state_container: ${{ steps.compute_env_state_container.outputs.env_state_container }}
       environment_file: ${{ steps.env.outputs.environment_file }}
     steps:
       - name: Log start
@@ -77,14 +77,14 @@ jobs:
             echo "environment_file=$ENV_FILE"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Set storage container name
-        id: container
+      - name: Compute state container name
+        id: compute_env_state_container
         shell: bash
         run: |
           set -euo pipefail
           IFS=$'\n\t'
-          CONTAINER_NAME=$(echo "${{ steps.env.outputs.env_short_name }}${{ steps.env.outputs.environment }}${{ steps.env.outputs.location }}" | tr '[:upper:]' '[:lower:]' | tr ' _' '-')
-          echo "container_name=$CONTAINER_NAME" >> "$GITHUB_OUTPUT"
+          ENV_STATE_CONTAINER=$(echo "envstate-${{ steps.env.outputs.env_short_name }}-${{ steps.env.outputs.environment }}-${{ steps.env.outputs.location }}" | tr '[:upper:]' '[:lower:]' | tr ' _' '-')
+          echo "env_state_container=$ENV_STATE_CONTAINER" >> "$GITHUB_OUTPUT"
 
       - name: Log summary
         if: success()
@@ -197,7 +197,7 @@ jobs:
           terraform -chdir=terraform init \
             -backend-config="resource_group_name=v1vhm-rg-vending-prod-uks-001" \
             -backend-config="storage_account_name=vendingtfstate" \
-            -backend-config="container_name=${{ needs.prepare.outputs.container_name }}" \
+            -backend-config="container_name=${{ needs.prepare.outputs.env_state_container }}" \
             -backend-config="key=${{ needs.prepare.outputs.product_identifier }}_${{ needs.prepare.outputs.environment }}_${{ needs.prepare.outputs.location }}.tfstate" \
             -reconfigure
 
@@ -287,7 +287,7 @@ jobs:
       ENVIRONMENT: ${{ needs.prepare.outputs.environment }}
       LOCATION: ${{ needs.prepare.outputs.location }}
       ENV_SHORT_NAME: ${{ needs.prepare.outputs.env_short_name }}
-      CONTAINER_NAME: ${{ needs.prepare.outputs.container_name }}
+      ENV_STATE_CONTAINER: ${{ needs.prepare.outputs.env_state_container }}
       ENV_FILE: ${{ needs.prepare.outputs.environment_file }}
     steps:
       - name: Log start

--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -49,7 +49,7 @@ jobs:
       PORT_CLIENT_SECRET: ${{ secrets.PORT_CLIENT_SECRET }}
     outputs:
       environment_file: ${{ steps.create_env_file.outputs.path }}
-      container_name: ${{ steps.compute_container.outputs.name }}
+      env_state_container: ${{ steps.compute_env_state_container.outputs.name }}
       state_file_container_id: ${{ steps.compute_state_container_id.outputs.id }}
     steps:
       - name: Start run
@@ -135,24 +135,24 @@ jobs:
           git commit -m "Add environment $FILE_BASENAME"
           git push origin HEAD:main
 
-      - name: Compute container name
-        id: compute_container
+      - name: Compute state container name
+        id: compute_env_state_container
         run: |
-          CONTAINER_NAME=$(echo "${{ inputs.product_short_name }}${{ inputs.environment }}${{ inputs.location }}" | tr '[:upper:]' '[:lower:]' | tr ' _' '-')
-          echo "name=$CONTAINER_NAME" >> $GITHUB_OUTPUT
-          echo "CONTAINER_NAME=$CONTAINER_NAME" >> $GITHUB_ENV
+          ENV_STATE_CONTAINER=$(echo "envstate-${{ inputs.product_short_name }}-${{ inputs.environment }}-${{ inputs.location }}" | tr '[:upper:]' '[:lower:]' | tr ' _' '-')
+          echo "name=$ENV_STATE_CONTAINER" >> $GITHUB_OUTPUT
+          echo "ENV_STATE_CONTAINER=$ENV_STATE_CONTAINER" >> $GITHUB_ENV
 
       - name: Create state container
         run: |
           az storage container create \
-            --name $CONTAINER_NAME \
+            --name $ENV_STATE_CONTAINER \
             --account-name vendingtfstate \
             --resource-group v1vhm-rg-vending-prod-uks-001 \
             --auth-mode login
       - name: Compute state container id
         id: compute_state_container_id
         run: |
-          STATE_FILE_CONTAINER_ID=$(echo "vendingtfstate-${CONTAINER_NAME}" | tr '[:upper:]' '[:lower:]')
+          STATE_FILE_CONTAINER_ID=$(echo "vendingtfstate-${ENV_STATE_CONTAINER}" | tr '[:upper:]' '[:lower:]')
           echo "STATE_FILE_CONTAINER_ID=$STATE_FILE_CONTAINER_ID" >> $GITHUB_ENV
           echo "id=$STATE_FILE_CONTAINER_ID" >> $GITHUB_OUTPUT
       - name: Upsert state container
@@ -164,7 +164,7 @@ jobs:
           operation: UPSERT
           blueprint: azureStorageContainer
           identifier: ${{ env.STATE_FILE_CONTAINER_ID }}
-          title: ${{ env.CONTAINER_NAME }}
+          title: ${{ env.ENV_STATE_CONTAINER }}
           relations: >-
             {"storageAccount": "/subscriptions/${{ env.ARM_SUBSCRIPTION_ID }}/resourcegroups/v1vhm-rg-vending-prod-uks-001/providers/microsoft.storage/storageaccounts/vendingtfstate"}
           properties: '{}'
@@ -177,7 +177,7 @@ jobs:
           baseUrl: https://api.getport.io
           operation: PATCH_RUN
           runId: ${{ env.PORT_RUN_ID }}
-          logMessage: 'Prepared ${{ steps.create_env_file.outputs.path }} and container ${{ steps.compute_container.outputs.name }}'
+          logMessage: 'Prepared ${{ steps.create_env_file.outputs.path }} and container ${{ steps.compute_env_state_container.outputs.name }}'
 
       - name: Log preparation failure
         if: failure()
@@ -207,7 +207,7 @@ jobs:
       PORT_CLIENT_ID: ${{ secrets.PORT_CLIENT_ID }}
       PORT_CLIENT_SECRET: ${{ secrets.PORT_CLIENT_SECRET }}
       TF_VAR_environment_file: ${{ github.workspace }}/${{ needs.prepare.outputs.environment_file }}
-      CONTAINER_NAME: ${{ needs.prepare.outputs.container_name }}
+      ENV_STATE_CONTAINER: ${{ needs.prepare.outputs.env_state_container }}
     outputs:
       plan_path: ${{ steps.plan.outputs.path }}
       plan_summary: ${{ steps.summarize.outputs.summary }}
@@ -247,7 +247,7 @@ jobs:
           terraform -chdir=terraform init \
             -backend-config="resource_group_name=v1vhm-rg-vending-prod-uks-001" \
             -backend-config="storage_account_name=vendingtfstate" \
-            -backend-config="container_name=${CONTAINER_NAME}" \
+            -backend-config="container_name=${ENV_STATE_CONTAINER}" \
             -backend-config="key=${{ inputs.product_identifier }}_${{ inputs.environment }}_${{ inputs.location }}.tfstate" \
             -reconfigure
 
@@ -312,7 +312,7 @@ jobs:
       PORT_CLIENT_ID: ${{ secrets.PORT_CLIENT_ID }}
       PORT_CLIENT_SECRET: ${{ secrets.PORT_CLIENT_SECRET }}
       TF_VAR_environment_file: ${{ github.workspace }}/${{ needs.prepare.outputs.environment_file }}
-      CONTAINER_NAME: ${{ needs.prepare.outputs.container_name }}
+      ENV_STATE_CONTAINER: ${{ needs.prepare.outputs.env_state_container }}
       STATE_FILE_CONTAINER_ID: ${{ needs.prepare.outputs.state_file_container_id }}
     outputs:
       commit_sha: ${{ steps.commit.outputs.sha }}
@@ -367,7 +367,7 @@ jobs:
           terraform -chdir=terraform init \
             -backend-config="resource_group_name=v1vhm-rg-vending-prod-uks-001" \
             -backend-config="storage_account_name=vendingtfstate" \
-            -backend-config="container_name=${CONTAINER_NAME}" \
+            -backend-config="container_name=${ENV_STATE_CONTAINER}" \
             -backend-config="key=${{ inputs.product_identifier }}_${{ inputs.environment }}_${{ inputs.location }}.tfstate" \
             -reconfigure
 

--- a/scripts/test-harness.sh
+++ b/scripts/test-harness.sh
@@ -18,11 +18,11 @@ FILE_STEM="$(echo "${PRODUCT_SHORT_NAME}_${ENVIRONMENT}_${LOCATION}" | tr '[:upp
 ENVIRONMENT_IDENTIFIER="$(echo "${PRODUCT_IDENTIFIER}_${ENVIRONMENT}_${LOCATION}" | tr '[:upper:]' '[:lower:]' | tr ' ' '_')"
 ENVIRONMENT_TITLE="${PRODUCT_NAME} ${ENVIRONMENT}"
 ENV_FILE="environments/${FILE_STEM}.yaml"
-CONTAINER_NAME="$(echo "${PRODUCT_SHORT_NAME}${ENVIRONMENT}${LOCATION}" | tr '[:upper:]' '[:lower:]' | tr ' _' '-')"
+ENV_STATE_CONTAINER="$(echo "envstate-${PRODUCT_SHORT_NAME}-${ENVIRONMENT}-${LOCATION}" | tr '[:upper:]' '[:lower:]' | tr ' _' '-')"
 STATE_FILE_KEY="${PRODUCT_IDENTIFIER}_${ENVIRONMENT}_${LOCATION}.tfstate"
 
 export TF_VAR_environment_file="$PWD/$ENV_FILE"
-export CONTAINER_NAME="$CONTAINER_NAME"
+export ENV_STATE_CONTAINER
 export TF_VAR_port_run_id=""
 export ARM_SUBSCRIPTION_ID="da7f852b-9a37-4283-a8c0-de1dafd6cb1f"
 
@@ -31,7 +31,7 @@ echo "==> Running terraform init"
 terraform -chdir=terraform init \
   -backend-config="resource_group_name=v1vhm-rg-vending-prod-uks-001" \
   -backend-config="storage_account_name=vendingtfstate" \
-  -backend-config="container_name=${CONTAINER_NAME}" \
+  -backend-config="container_name=${ENV_STATE_CONTAINER}" \
   -backend-config="key=${STATE_FILE_KEY}" \
   -reconfigure | tee terraform-init.log
 


### PR DESCRIPTION
## Summary
- derive `ENV_STATE_CONTAINER` from inputs and use for storage container
- point Terraform backend config at `ENV_STATE_CONTAINER` everywhere

## Testing
- `shellcheck scripts/test-harness.sh`
- `actionlint .github/workflows/provision.yml .github/workflows/associate-service.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a7189364708330b7ff4e42c70040d3