### PR TITLE
Separate vending and deployment state containers

### DIFF
--- a/.github/workflows/associate-service.yml
+++ b/.github/workflows/associate-service.yml
@@ -160,9 +160,10 @@ jobs:
           for svc in services:
               if svc.get('service_identifier') == service_id:
                   svc['github'] = {'repository': github_repo}
+                  svc.setdefault('deployment_state_container', None)
                   break
           else:
-              services.append({'service_identifier': service_id, 'github': {'repository': github_repo}})
+              services.append({'service_identifier': service_id, 'deployment_state_container': None, 'github': {'repository': github_repo}})
           data['services'] = services
           data['port_run_id'] = port_run_id
           with open(env_file, 'w') as f:
@@ -229,6 +230,20 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
           exit $status
 
+      - name: Install yq
+        if: success()
+        run: sudo snap install yq --classic
+
+      - name: Record deployment state container
+        if: success()
+        shell: bash
+        run: |
+          set -euo pipefail
+          IFS=$'\n\t'
+          terraform -chdir=terraform output -json > tfoutput.json
+          ID=$(jq -r ".service_containers.value.\"${{ inputs.service_identifier }}\".id" tfoutput.json)
+          yq e -i "(.services[] | select(.service_identifier == \"${{ inputs.service_identifier }}\") | .deployment_state_container) = \"$ID\"" "$TF_VAR_environment_file"
+
       - name: Commit updated environment file
         if: success()
         shell: bash
@@ -289,6 +304,7 @@ jobs:
       ENV_SHORT_NAME: ${{ needs.prepare.outputs.env_short_name }}
       ENV_STATE_CONTAINER: ${{ needs.prepare.outputs.env_state_container }}
       ENV_FILE: ${{ needs.prepare.outputs.environment_file }}
+      SERVICE_IDENTIFIER: ${{ inputs.service_identifier }}
     steps:
       - name: Log start
         uses: port-labs/port-github-action@v1
@@ -313,6 +329,10 @@ jobs:
           properties: >-
             {"status": "Configuring Service"}
 
+      - name: Install yq
+        if: ${{ needs.terraform.result == 'success' }}
+        run: sudo snap install yq --classic
+
       - name: Compute state container identifier
         if: ${{ needs.terraform.result == 'success' }}
         id: state_container
@@ -320,7 +340,7 @@ jobs:
         run: |
           set -euo pipefail
           IFS=$'\n\t'
-          STATE_CONTAINER=$(grep '^state_file_container:' "$ENV_FILE" | awk '{print $2}')
+          STATE_CONTAINER=$(yq e ".services[] | select(.service_identifier == \"$SERVICE_IDENTIFIER\") | .deployment_state_container" "$ENV_FILE")
           echo "id=$STATE_CONTAINER" >> "$GITHUB_OUTPUT"
 
       - name: Link request to state container

--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -117,6 +117,7 @@ jobs:
           product_name: ${{ inputs.product_name }}
           product_identifier: ${{ inputs.product_identifier }}
           port_run_id: $PORT_RUN_ID
+          vending_state_container:
           EOF
           echo "path=$FILE_PATH" >> $GITHUB_OUTPUT
 
@@ -402,25 +403,35 @@ jobs:
           set -euo pipefail
           IFS=$'\n\t'
           terraform -chdir=terraform output -json > tfoutput.json
-          for key in deployment_environment deployment_identity azure_subscription state_file_container user_managed_identity_client_id; do
+          for key in deployment_environment deployment_identity azure_subscription user_managed_identity_client_id; do
             value=$(jq -r ".${key}.value" tfoutput.json)
             varname=$(echo "$key" | tr '[:lower:]' '[:upper:]')
             echo "${varname}=$value" >> "$GITHUB_ENV"
           done
+          SERVICE_CONTAINERS=$(jq -c '.service_containers.value' tfoutput.json)
+          echo "SERVICE_CONTAINERS=$SERVICE_CONTAINERS" >> "$GITHUB_ENV"
 
       - uses: actions/upload-artifact@v4
         with:
           name: tfoutput
           path: tfoutput.json
 
+      - name: Install yq
+        run: sudo snap install yq --classic
+
       - name: Append outputs to environment file
         run: |
+          set -euo pipefail
+          IFS=$'\n\t'
           {
             echo "deployment_environment: $DEPLOYMENT_ENVIRONMENT"
             echo "deployment_identity: $DEPLOYMENT_IDENTITY"
             echo "azure_subscription: $AZURE_SUBSCRIPTION"
-            echo "state_file_container: $STATE_FILE_CONTAINER"
           } >> "$TF_VAR_environment_file"
+          yq e -i ".vending_state_container = \"$ENV_STATE_CONTAINER\"" "$TF_VAR_environment_file"
+          echo "$SERVICE_CONTAINERS" | jq -r 'to_entries[] | "\(.key)=\(.value.id)"' | while IFS='=' read -r svc id; do
+            yq e -i "(.services[] | select(.service_identifier == \"$svc\") | .deployment_state_container) = \"$id\"" "$TF_VAR_environment_file"
+          done
 
       - name: Commit updated environment file
         id: commit
@@ -475,18 +486,30 @@ jobs:
         with:
           ref: main
 
+      - name: Install yq
+        run: sudo snap install yq --classic
+
       - name: Load deployment metadata
+        shell: bash
         run: |
+          set -euo pipefail
+          IFS=$'\n\t'
           DEPLOYMENT_ENVIRONMENT=$(grep '^deployment_environment:' "$ENV_FILE" | awk '{print $2}')
           DEPLOYMENT_IDENTITY=$(grep '^deployment_identity:' "$ENV_FILE" | awk '{print $2}')
           AZURE_SUBSCRIPTION=$(grep '^azure_subscription:' "$ENV_FILE" | awk '{print $2}')
-          STATE_FILE_CONTAINER=$(grep '^state_file_container:' "$ENV_FILE" | awk '{print $2}')
-          test -n "$DEPLOYMENT_ENVIRONMENT" && test -n "$DEPLOYMENT_IDENTITY" && test -n "$AZURE_SUBSCRIPTION" && test -n "$STATE_FILE_CONTAINER"
+          VENDING_STATE_CONTAINER=$(grep '^vending_state_container:' "$ENV_FILE" | awk '{print $2}')
+          if yq e '.services | length > 0' "$ENV_FILE" >/dev/null; then
+            MISSING=$(yq e '.services[] | select(.deployment_state_container == null or .deployment_state_container == "") | length' "$ENV_FILE")
+            if [ "$MISSING" != "0" ]; then
+              echo "::error::missing deployment_state_container for service" >&2
+              exit 1
+            fi
+          fi
           {
             echo "DEPLOYMENT_ENVIRONMENT=$DEPLOYMENT_ENVIRONMENT"
             echo "DEPLOYMENT_IDENTITY=$DEPLOYMENT_IDENTITY"
             echo "AZURE_SUBSCRIPTION=$AZURE_SUBSCRIPTION"
-            echo "STATE_FILE_CONTAINER=$STATE_FILE_CONTAINER"
+            echo "VENDING_STATE_CONTAINER=$VENDING_STATE_CONTAINER"
           } >> "$GITHUB_ENV"
 
       - name: Log start finalize
@@ -504,9 +527,6 @@ jobs:
 
       - name: Verify environment file
         run: test -f "$ENV_FILE"
-
-      - name: Install yq
-        run: sudo snap install yq --classic
 
       - name: Mark environment as succeeded
         if: ${{ success() }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,11 +26,12 @@ The high‑level layout is:
   ```yaml
   services:
     - service_identifier: my-service
+      deployment_state_container: mystatecontainer
       github:
         repository: org/my-service-repo
   ```
 
-  Terraform creates a storage container named after each `service_identifier` and configures a GitHub OIDC federated credential for that service.  When creating new environment files, adhere to this schema.
+  Terraform creates a storage container named after each `service_identifier`, records its identifier under `deployment_state_container` and configures a GitHub OIDC federated credential for that service.  When creating new environment files, adhere to this schema.
 * **File names:** Environment files are named `${product_short_name}_${environment}_${location}.yaml`.  The workflow uses the short name and environment tier to build this file name and related resource names.  Do not include spaces or uppercase letters in file names.  The workflow also uses `${product_short_name}_${environment}_${location}` for the state container name and YAML file inside the job, so ensure the values are valid for Azure storage container naming (lowercase alphanumeric and hyphens; length ≤ 63 characters).
 * **Terraform state:** A recent change introduced a separate state file per environment (see commit message *"Create a new state file for each environment"*).  If adding new environments or modifying the backend configuration, keep this behaviour by using a unique `key` in `backend.tf` (e.g., `${product_identifier}_${environment}_${location}.tfstate`).  Avoid using a single shared `terraform.tfstate` for all environments.
 * **Port entities:** The Terraform root registers a Port *environment* entity using the `product_identifier`, environment tier and location as the identifier and title.  Do not revert to using the short name here; a recent commit corrected this (see commit *"port objects now use correct identifier"*).  When adding properties or relations to Port entities, ensure that identifiers remain stable (changing them will orphan existing records).  Services relate to this entity through the optional `services` list, and the root upserts an `azureStorageContainer` entity for each service container.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ status: in_progress        # then succeeded | failed
 port_run_id: abcde12345       # Port action run id
 product_name: Demo Product
 product_identifier: prod-12345     # product identifier from Port
+vending_state_container: envstate-prod-12345-dev-eastus
 services:
   - service_identifier: my-service
+    deployment_state_container: mystatecontainer
     github:
       repository: org/my-service-repo
 deployment_environment: /subscriptions/.../resourceGroups/rg-prod-12345-dev-eastus
@@ -22,7 +24,7 @@ deployment_identity: /subscriptions/.../providers/Microsoft.ManagedIdentity/user
 azure_subscription: /subscriptions/...      # subscription id
 ```
 
-The `status` line records the workflow's progress: it starts as `in_progress` and is later set to `succeeded` or `failed`. The `product_name` and `product_identifier` fields record the owning product. Services are associated with an environment later, so `services` may be omitted or left as an empty list. When services are listed, Terraform creates a storage container named after each `service_identifier` and configures a GitHub OIDC federated credential for that service. The root module upserts a Port `azureStorageContainer` entity for every service container. The fields `deployment_environment`, `deployment_identity` and `azure_subscription` are appended after provisioning and are used to create the Port environment entity outside of Terraform. The file is committed when created, updated with outputs and finalized with the workflow result.
+The `status` line records the workflow's progress: it starts as `in_progress` and is later set to `succeeded` or `failed`. The `product_name` and `product_identifier` fields record the owning product. `vending_state_container` stores the provisioning state container used by Terraform. Services are associated with an environment later, so `services` may be omitted or left as an empty list. When services are listed, Terraform creates a storage container named after each `service_identifier`, records its identifier under `deployment_state_container`, and configures a GitHub OIDC federated credential for that service. The root module upserts a Port `azureStorageContainer` entity for every service container. The fields `deployment_environment`, `deployment_identity` and `azure_subscription` are appended after provisioning and are used to create the Port environment entity outside of Terraform. The file is committed when created, updated with outputs and finalized with the workflow result.
 
 Managed identities and federated credentials are created automatically by Terraform. The identity is granted Owner access to the resource group and Storage Blob Data Contributor access to the storage account. The resource group is tagged with the environment, product identifier and product name, GitHub organization and repository so that ownership is clear.
 

--- a/environments/testpr_dev_uksouth.yaml
+++ b/environments/testpr_dev_uksouth.yaml
@@ -9,8 +9,9 @@ status: succeeded
 deployment_environment: /subscriptions/da7f852b-9a37-4283-a8c0-de1dafd6cb1f/resourcegroups/rg-testpr-dev-uksouth
 deployment_identity: /subscriptions/da7f852b-9a37-4283-a8c0-de1dafd6cb1f/resourcegroups/rg-testpr-dev-uksouth/providers/microsoft.managedidentity/userassignedidentities/uai-testpr-dev-uksouth
 azure_subscription: /subscriptions/da7f852b-9a37-4283-a8c0-de1dafd6cb1f
-state_file_container: null
+vending_state_container: null
 services:
 - service_identifier: testpr-infra
+  deployment_state_container: null
   github:
     repository: v1vhm/testpr-infra

--- a/environments/testpr_test_uksouth.yaml
+++ b/environments/testpr_test_uksouth.yaml
@@ -9,5 +9,5 @@ status: succeeded
 deployment_environment: /subscriptions/da7f852b-9a37-4283-a8c0-de1dafd6cb1f/resourcegroups/rg-testpr-test-uksouth
 deployment_identity: /subscriptions/da7f852b-9a37-4283-a8c0-de1dafd6cb1f/resourcegroups/rg-testpr-test-uksouth/providers/microsoft.managedidentity/userassignedidentities/uai-testpr-test-uksouth
 azure_subscription: /subscriptions/da7f852b-9a37-4283-a8c0-de1dafd6cb1f
-state_file_container: null
+vending_state_container: null
 services: []

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -146,3 +146,7 @@ output "user_managed_identity_client_id" {
   value = module.environment.user_managed_identity_client_id
 }
 
+output "service_containers" {
+  value = module.environment.service_containers
+}
+


### PR DESCRIPTION
## Summary
- record provisioning container and per-service deployment containers in environment files
- update provisioning and service-association workflows to capture and validate service deployment containers
- document new vending_state_container and service-level deployment_state_container schema

## Testing
- `/root/.local/share/mise/installs/go/1.24.3/bin/actionlint`
- `yamllint -d '{extends: relaxed, rules: {line-length: disable}}' .github/workflows/provision.yml .github/workflows/associate-service.yml environments/testpr_dev_uksouth.yaml environments/testpr_test_uksouth.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68a71b65def483309aae60a76508848b