### PR TITLE
Remove service deployment state check in provision workflow

### DIFF
--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -498,13 +498,6 @@ jobs:
           DEPLOYMENT_IDENTITY=$(grep '^deployment_identity:' "$ENV_FILE" | awk '{print $2}')
           AZURE_SUBSCRIPTION=$(grep '^azure_subscription:' "$ENV_FILE" | awk '{print $2}')
           VENDING_STATE_CONTAINER=$(grep '^vending_state_container:' "$ENV_FILE" | awk '{print $2}')
-          if yq e '.services | length > 0' "$ENV_FILE" >/dev/null; then
-            MISSING=$(yq e '.services[] | select(.deployment_state_container == null or .deployment_state_container == "") | length' "$ENV_FILE")
-            if [ "$MISSING" != "0" ]; then
-              echo "::error::missing deployment_state_container for service" >&2
-              exit 1
-            fi
-          fi
           {
             echo "DEPLOYMENT_ENVIRONMENT=$DEPLOYMENT_ENVIRONMENT"
             echo "DEPLOYMENT_IDENTITY=$DEPLOYMENT_IDENTITY"


### PR DESCRIPTION
## Summary
- stop failing finalize stage when service `deployment_state_container` is absent

## Testing
- `/root/.local/share/mise/installs/go/1.24.3/bin/actionlint .github/workflows/provision.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a749f01b7c8330a31d85190b6517db